### PR TITLE
Add /review workflow for PR code reviews

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,76 @@
+name: Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: github.event.sender.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Get PR number
+        id: pr-number
+        run: |
+          echo "number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Get PR details
+        id: pr-details
+        run: |
+          gh api /repos/${{ github.repository }}/pulls/${{ steps.pr-number.outputs.number }} > pr_data.json
+          echo "title=$(jq -r .title pr_data.json)" >> $GITHUB_OUTPUT
+          echo "sha=$(jq -r .head.sha pr_data.json)" >> $GITHUB_OUTPUT
+          {
+            echo 'body<<EOF'
+            jq -r .body pr_data.json
+            echo EOF
+          } >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Bonk
+        uses: ask-bonk/ask-bonk/github@main
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode/claude-opus-4-5
+          mentions: "/review"
+          permissions: write
+          agent: reviewer
+          prompt: |
+            Review the following pull request (title: ${{ steps.pr-details.outputs.title }}) against the below review guidelines:
+
+            Please check all the code changes in this pull request against the style guide, also look for any bugs if they exist. Diffs are important but make sure you read the entire file to get proper context. Make it clear the suggestions are merely suggestions and the human can decide what to do.
+
+            Refer to AGENTS.md and any additional instructions for our style guide, conventions and repo-wide rules.
+
+            1. Focus on actual violations and bugs. Where possible, comment on the exact line number to help guide the reviewer.
+            2. Break up "needs fixing" (real logic bugs, poor error handling, security issues) vs. "suggestions" (nested logic, unused code, code structure/maintenance guidance) when responding so that a human has clear, actionable feedback.
+            3. Use the gh cli to create comments on the files (or line numbers) where relevant. Use suggestions to suggest fixes, especially where you have high-confidence in the fix. Ensure fixes are valid code and take into account the surrounding code (opening/closing braces, indentation, comments).
+
+            In general, aim to provide actionable comments > code suggestions.
+
+            <pr_number>
+            ${{ steps.pr-number.outputs.number }}
+            </pr_number>
+            <pr_description>
+            ${{ steps.pr-details.outputs.body }}
+            </pr_description>
+
+            If the PR looks good, respond with only "LGTM!". No need to pad your response if the PR passes review.


### PR DESCRIPTION
## Summary

- Adds a new GitHub Actions workflow triggered by `/review` comments on PRs
- Fetches PR details (title, description) and passes them to a custom prompt
- Uses `agent: reviewer` (placeholder for future reviewer agent)
- Provides structured review guidelines focusing on actionable feedback vs suggestions