### PR TITLE
Clarify review prompt to only make one summary comment

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -69,8 +69,9 @@ jobs:
             1. Focus on actual violations and bugs. Where possible, comment on the exact line number to help guide the reviewer.
             2. Break up "needs fixing" (real logic bugs, poor error handling, security issues) vs. "suggestions" (nested logic, unused code, code structure/maintenance guidance) when responding so that a human has clear, actionable feedback.
             3. Use the gh cli to create comments on the files (or line numbers) where relevant. Use suggestions to suggest fixes, especially where you have high-confidence in the fix. Ensure fixes are valid code and take into account the surrounding code (opening/closing braces, indentation, comments).
+            4. ONLY create ONE (1) summary comment as a PR review comment, if needed. Do not make additional comments to summarize the review.
 
-            In general, aim to provide actionable comments > code suggestions. Make line level comments and only ONE summary comment as a PR review comment. Do not make additional PR comments or summary comments.
+            In general, aim to provide actionable comments > code suggestions. 
 
             <pr_number>
             ${{ steps.pr-number.outputs.number }}


### PR DESCRIPTION
## Summary

- Updates the review workflow prompt to explicitly instruct OpenCode to make only ONE summary comment as a PR review
- Prevents duplicate issue comments and multiple review submissions from a single `/review` invocation