### PR TITLE
fix: use gh api with token for opencode version lookup

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -191,8 +191,10 @@ runs:
       if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
       id: version
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        VERSION=$(curl -sf https://api.github.com/repos/sst/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        VERSION=$(gh api repos/sst/opencode/releases/latest --jq '.tag_name' 2>/dev/null || echo "latest")
         echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
 
     - name: Cache opencode


### PR DESCRIPTION
- Use `gh api` with the workflow's built-in `GITHUB_TOKEN` instead of unauthenticated `curl` to fetch the latest OpenCode version
- Fixes rate limit failures (60 req/hr unauthenticated vs 5000 req/hr with token)
- Adds proper fallback to "latest" if the API call fails for any reason
