### PR TITLE
reorganize stats into /stats/events, /stats/errors, /stats/actors

### DIFF
--- a/ae_queries/events_by_actor.sql
+++ b/ae_queries/events_by_actor.sql
@@ -1,0 +1,11 @@
+-- Webhook events per actor (last 30 days)
+SELECT
+  blob4 AS actor,
+  COUNT() AS event_count
+FROM bonk_events
+WHERE timestamp > NOW() - INTERVAL '30' DAY
+  AND blob1 = 'webhook'
+  AND blob4 != ''
+GROUP BY actor
+ORDER BY event_count DESC
+LIMIT 100


### PR DESCRIPTION
## Summary

Replaces the flat `/stats` and `/errors` endpoints with a `/stats` route group containing three sub-endpoints.

The old `/stats` only showed events per repo, and `/errors` was JSON-only with no bar chart. Now everything lives under `/stats/*`, all endpoints default to ASCII bar chart with `?format=json` opt-in, and there's a new actors view.

- `GET /stats/events` — webhook events per repo, last 30d (was `/stats`)
- `GET /stats/errors` — errors by repo, last 24h (was `/errors`, now includes bar chart)
- `GET /stats/actors` — webhook events per GitHub actor, last 30d (new, queries `blob4`)
- shared middleware on the stats sub-router validates Analytics Engine config once
- `renderBarChart` generalized to accept `labelKey`/`valueKey` instead of hardcoded field names