### PR TITLE
filter /stats/actors to mentions only

### DIFF
--- a/ae_queries/events_by_actor.sql
+++ b/ae_queries/events_by_actor.sql
@@ -1,10 +1,11 @@
--- Webhook events per actor (last 30 days)
+-- Mentions per actor (last 30 days)
 SELECT
   blob4 AS actor,
   COUNT() AS event_count
 FROM bonk_events
 WHERE timestamp > NOW() - INTERVAL '30' DAY
   AND blob1 = 'webhook'
+  AND blob2 IN ('issue_comment', 'pull_request_review_comment', 'issues')
   AND blob4 != ''
 GROUP BY actor
 ORDER BY event_count DESC

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,7 +142,7 @@ stats.get("/actors", async (c) => {
     const data = await queryAnalyticsEngine(c.env, eventsByActorQuery);
     if (c.req.query("format") === "json") return c.json({ data });
     return c.text(
-      renderBarChart(data, "Webhook events per actor (last 30d)", "actor", "event_count"),
+      renderBarChart(data, "Mentions per actor (last 30d)", "actor", "event_count"),
     );
   } catch (error) {
     log.errorWithException("stats_query_failed", error);


### PR DESCRIPTION
/stats/actors was counting all webhook events per actor, including schedule, workflow_dispatch, installation, and skipped events.

- filter events_by_actor.sql query to only user-initiated event subtypes (issue_comment, pull_request_review_comment, issues)
- update chart title to "Mentions per actor"