### PR TITLE
use track events for /stats/actors instead of webhook events

### DIFF
--- a/ae_queries/events_by_actor.sql
+++ b/ae_queries/events_by_actor.sql
@@ -1,11 +1,11 @@
--- Mentions per actor (last 30 days)
+-- Mentions per actor (last 7 days)
+-- track events fire when a GitHub Action confirms an @mention and starts a workflow
 SELECT
   blob4 AS actor,
   COUNT() AS event_count
 FROM bonk_events
-WHERE timestamp > NOW() - INTERVAL '30' DAY
-  AND blob1 = 'webhook'
-  AND blob2 IN ('issue_comment', 'pull_request_review_comment')
+WHERE timestamp > NOW() - INTERVAL '7' DAY
+  AND blob1 = 'track'
   AND blob4 != ''
 GROUP BY actor
 ORDER BY event_count DESC


### PR DESCRIPTION
/stats/actors was still showing generic webhook events (any comment or PR review on an installed repo) rather than actual @mentions. The webhook handler doesn't know if a comment is a mention — that filtering happens in the GitHub Action, which calls /api/github/track only after confirming a mention.

- switch SQL query from `blob1 = 'webhook'` to `blob1 = 'track'`, which only fires on confirmed mentions
- extract `claims.actor` from the already-validated OIDC token in both POST and PUT /track handlers, pass into `emitMetric()` and logger context
- reduce query window to 7 days while historical data without actor backfills