### PR TITLE
update workers types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,11 +18,11 @@ export interface Env {
   GITHUB_APP_PRIVATE_KEY: string;
   GITHUB_WEBHOOK_SECRET: string;
   OPENCODE_API_KEY: string;
-  DEFAULT_MODEL?: string;
+  DEFAULT_MODEL: string;
   // Shared secret for /ask endpoint - empty means endpoint is disabled
   ASK_SECRET?: string;
   // Allowed orgs/users for GitHub App installation - JSON array binding
-  ALLOWED_ORGS?: string[];
+  ALLOWED_ORGS: string[];
   // Analytics Engine query API credentials (for /stats endpoint)
   CLOUDFLARE_ACCOUNT_ID?: string;
   ANALYTICS_TOKEN?: string;

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -10,8 +10,8 @@ declare namespace Cloudflare {
 		APP_INSTALLATIONS: KVNamespace;
 		BONK_EVENTS: AnalyticsEngineDataset;
 		RATE_LIMITER: RateLimit;
-		DEFAULT_MODEL: "opencode/claude-opus-4-5";
-		ALLOWED_ORGS: ["elithrar","cloudflare","ask-bonk"];
+		DEFAULT_MODEL: string;
+		ALLOWED_ORGS: string[];
 		Sandbox: DurableObjectNamespace<import("./src/index").Sandbox>;
 		REPO_AGENT: DurableObjectNamespace<import("./src/index").RepoAgent>;
 	}


### PR DESCRIPTION
Regenerate `worker-configuration.d.ts` with latest `wrangler types`.

- upgrades runtime types from `workerd@1.20251210.0` to `workerd@1.20260205.0`
- populates `Cloudflare.Env` with actual bindings (KV, Analytics, Rate Limiter, Durable Objects)
- adds `ProcessEnv` type augmentation for stringified env vars
- adds module declarations for `.hbs` and `.sql` imports