### PR TITLE
remove dead ISSUE_ID field, add deleted-fork test

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -320,7 +320,6 @@ runs:
         COMMENT_ID: ${{ github.event.comment.id }}
         COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
         ISSUE_CREATED_AT: ${{ github.event.issue.created_at || github.event.pull_request.created_at }}
-        ISSUE_ID: ${{ github.event.issue.id || github.event.pull_request.id }}
       run: bun run ${{ github.action_path }}/script/track.ts
 
     - name: Build prompt

--- a/github/script/context.ts
+++ b/github/script/context.ts
@@ -8,7 +8,6 @@ export interface Repo {
 
 export interface Issue {
   number: number;
-  id?: number;
 }
 
 export interface Comment {
@@ -53,18 +52,13 @@ export function getContext(): Context {
   }
 
   const issueNumber = process.env.ISSUE_NUMBER || process.env.PR_NUMBER;
-  const issueId = process.env.ISSUE_ID;
   const commentId = process.env.COMMENT_ID;
-  const createdAt = process.env.COMMENT_CREATED_AT || process.env.ISSUE_CREATED_AT;
+  const createdAt =
+    process.env.COMMENT_CREATED_AT || process.env.ISSUE_CREATED_AT;
 
   return {
     repo: { owner, repo },
-    issue: issueNumber
-      ? {
-          number: parseInt(issueNumber, 10),
-          id: issueId ? parseInt(issueId, 10) : undefined,
-        }
-      : null,
+    issue: issueNumber ? { number: parseInt(issueNumber, 10) } : null,
     comment: commentId
       ? {
           id: parseInt(commentId, 10),

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -452,6 +452,22 @@ describe("Pull Request Event Parsing", () => {
     const result = parsePullRequestEvent(basePRPayload);
     expect(result.context.isFork).toBe(false);
   });
+
+  it("treats null head.repo as fork (deleted fork repo)", () => {
+    const payload = {
+      ...basePRPayload,
+      pull_request: {
+        ...basePRPayload.pull_request,
+        head: {
+          ...(basePRPayload as any).pull_request.head,
+          repo: null,
+        },
+      },
+    } as unknown as PullRequestEvent;
+
+    const result = parsePullRequestEvent(payload);
+    expect(result.context.isFork).toBe(true);
+  });
 });
 
 describe("Workflow Dispatch Event Parsing", () => {


### PR DESCRIPTION
Follow-up to #63. The code review flagged two items that didn't make it into the original PR.

- remove `ISSUE_ID` env var from action.yml "Track Bonk run" step -- nothing reads it anymore since track.ts uses `context.issue.number` directly
- remove `id` from the `Issue` interface and `issueId`/`ISSUE_ID` parsing in `context.ts` -- dead code, was the database ID which no consumer needs
- add test for `parsePullRequestEvent` with `head.repo: null` (deleted fork repo returns `isFork: true`)