### PR TITLE
fix deleted-fork detection across Worker and Action

### DIFF
--- a/github/script/prompt.ts
+++ b/github/script/prompt.ts
@@ -34,10 +34,8 @@ async function detectFork(): Promise<ForkDetectionResult> {
     case "pull_request":
     case "pull_request_review_comment":
     case "pull_request_review":
-      if (headRepo && baseRepo) {
-        return { isFork: headRepo !== baseRepo };
-      }
-      return { isFork: false };
+      // A null/missing head repo means the fork was deleted — still a fork PR.
+      return { isFork: !headRepo || headRepo !== baseRepo };
 
     case "issue_comment":
       // Only check if this is a comment on a PR (PR_NUMBER is set)
@@ -59,7 +57,8 @@ async function detectFork(): Promise<ForkDetectionResult> {
         };
         const head = pr.head?.repo?.full_name;
         const base = pr.base?.repo?.full_name;
-        const isFork = !!head && !!base && head !== base;
+        // A null/missing head repo means the fork was deleted — still a fork PR.
+        const isFork = !head || head !== base;
         return { isFork, headSha: pr.head?.sha };
       } catch {
         return { isFork: false };


### PR DESCRIPTION
Deleted-fork PRs (where `head.repo` is null after the source repo is removed) were silently misclassified as same-repo PRs, bypassing fork protections entirely — the agent ran with full write access instead of comment-only mode.

The bug existed in three independent fork-detection code paths:
- **Worker `isForkPR()`** (`src/events.ts`) — `undefined !== undefined` evaluated to `false`
- **Action `detectFork()` PR branch** (`github/script/prompt.ts`) — `if (headRepo && baseRepo)` guard failed, fell through to `{ isFork: false }`
- **Action `detectFork()` issue_comment branch** (`github/script/prompt.ts`) — `!!head && !!base && head !== base` returned `false` when head was undefined

Changes:
- extract a private `detectFork(head, base)` helper in `events.ts` with the correct guard: `!head || head !== base`
- `isForkPR()` and `parsePullRequestEvent()` both delegate to it, eliminating duplicated logic
- apply the same `!head || head !== base` fix to both branches of the Action-side `detectFork()` in `prompt.ts`
- un-export `isForkPR` (no external consumers)
- add deleted-fork tests for `parsePRReviewCommentEvent` and `parsePRReviewEvent` (previously only `parsePullRequestEvent` was covered)
- expand deleted-fork tests to assert `headBranch`/`headSha` survive null `head.repo`
- refactor `basePRPayload` to a plain object to eliminate `as any` casts on nested spreads

Tests: 50 pass, type check clean.