### PR TITLE
Add concurrency groups to workflow templates

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'
@@ -21,17 +25,14 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:
-          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_AI_GATEWAY_ACCOUNT_ID }}
+          CLOUDFLARE_GATEWAY_ID: ${{ secrets.CF_AI_GATEWAY_NAME }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_AI_GATEWAY_TOKEN }}
         with:
-          model: opencode/claude-opus-4-6
+          model: "cloudflare-ai-gateway/anthropic/claude-opus-4-6"
+          agent: docs # use our Docs agent by default in this repo
           mentions: "/bonk,@ask-bonk"
-          permissions: write
+          permissions: CODEOWNERS

--- a/cli/templates/bonk.yml.hbs
+++ b/cli/templates/bonk.yml.hbs
@@ -6,6 +6,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'

--- a/cli/templates/custom.yml.hbs
+++ b/cli/templates/custom.yml.hbs
@@ -3,6 +3,10 @@ name: {{NAME}}
 on:
 {{EVENTS}}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bonk:
     if: github.event.sender.type != 'Bot'

--- a/cli/templates/review.yml.hbs
+++ b/cli/templates/review.yml.hbs
@@ -4,6 +4,10 @@ on:
   pull_request_review_comment:
     types: [created]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   review:
     if: github.event.sender.type != 'Bot'

--- a/cli/templates/scheduled.yml.hbs
+++ b/cli/templates/scheduled.yml.hbs
@@ -5,6 +5,10 @@ on:
     - cron: "{{CRON}}"
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   scheduled:
     runs-on: ubuntu-latest

--- a/cli/templates/triage.yml.hbs
+++ b/cli/templates/triage.yml.hbs
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prevents duplicate workflow runs from stacking up when multiple events fire on the same PR or issue.

Without concurrency groups, rapid-fire comments or pushes can spawn overlapping runs that compete for resources and produce duplicate bot responses.

- Add `concurrency` blocks to all CLI workflow templates (`bonk`, `custom`, `review`, `scheduled`, `triage`) scoped to the relevant event context (PR number, issue number, or ref)
- All groups use `cancel-in-progress: false` so in-flight runs finish rather than getting killed
- Each template uses the narrowest appropriate scope — `review.yml` uses PR number only, `triage.yml` uses issue number only, `scheduled.yml` uses ref only
- Update this repo's `bonk.yml` to use Cloudflare AI Gateway routing, the Docs agent, and CODEOWNERS permissions