### PR TITLE
add workflow failure tracking and visibility

### DIFF
--- a/ae_queries/errors_by_repo.sql
+++ b/ae_queries/errors_by_repo.sql
@@ -1,14 +1,15 @@
--- Errors by repo with error classification (last 24 hours)
--- Shows error breakdown with error codes for debugging
+-- Failures by repo with classification (last 24 hours)
+-- Includes workflow failures, infra errors, and cancellations
 SELECT
   index1 AS repo,
   blob1 AS event_type,
+  blob3 AS status,
   blob5 AS error_code,
   COUNT() AS error_count,
   MAX(timestamp) AS last_occurrence
 FROM bonk_events
-WHERE blob3 = 'error'
+WHERE blob3 IN ('error', 'failure', 'cancelled')
   AND timestamp > NOW() - INTERVAL '24' HOUR
-GROUP BY repo, event_type, error_code
+GROUP BY repo, event_type, status, error_code
 ORDER BY error_count DESC
 LIMIT 50

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,6 +235,43 @@ export interface WorkflowDispatchPayload {
   workflow?: string;
 }
 
+// GitHub workflow_run event payload structure (minimal type: only fields we use)
+export interface WorkflowRunPayload {
+  action: string;
+  workflow_run: {
+    id: number;
+    name: string;
+    // Workflow file path relative to repo root, e.g. ".github/workflows/bonk.yml"
+    path: string;
+    status: string;
+    conclusion: string | null;
+    html_url: string;
+    event: string;
+    head_branch: string;
+  };
+  repository: {
+    owner: { login: string };
+    name: string;
+    full_name: string;
+    private: boolean;
+  };
+  sender: { login: string };
+}
+
+// Parsed context from a workflow_run webhook event
+export interface WorkflowRunContext {
+  owner: string;
+  repo: string;
+  runId: number;
+  conclusion: string | null;
+  workflowName: string;
+  // Workflow file path, e.g. ".github/workflows/bonk.yml"
+  workflowPath: string;
+  runUrl: string;
+  triggerEvent: string;
+  isPrivate: boolean;
+}
+
 // Request to start tracking a workflow run (POST /api/github/track)
 export interface TrackWorkflowRequest {
   owner: string;


### PR DESCRIPTION
Workflow failures were invisible -- the /stats/errors endpoint returned nothing despite real failures in Actions, and runs that failed before the track step (e.g. OIDC failures) left no trace.

- broaden AE query to include `failure` and `cancelled` alongside `error`
- add `workflow_run` webhook handler as a safety net for runs that were never tracked or never finalized
- filter on workflow file path (`bonk*.yml`) instead of display name, since users can customize names
- add `confused` reaction on the triggering comment when a run fails
- emit WAE metrics from `postFailureComment` so failures show up in /stats/errors
- track recently finalized runs in DO state to distinguish "already handled" from "never tracked"
- 7 new tests for `parseWorkflowRunEvent`

Requires enabling `workflow_run` in the GitHub App webhook subscriptions to cover pre-track failures.