### PR TITLE
add release notes guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,9 @@ log.error('startup_failed', { reason: 'missing config' });
 - GraphQL for fetching issue/PR context (avoids multiple REST calls)
 - REST for mutations (comments, reactions, PRs)
 
+### Releases
+- Ignore changes to `.github/` directories when writing release notes — those are internal workflow configs, not user-facing
+
 ### Durable Objects
 - `RepoAgent`: Tracks workflow runs per repo, posts failure comments
 - ID format: `{owner}/{repo}`


### PR DESCRIPTION
Exclude `.github/` directory changes from release notes — they're internal workflow configs, not user-facing.

- add Releases section to AGENTS.md Conventions