### PR TITLE
harden fork handling, OIDC resilience, and error recovery

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -92,6 +92,8 @@ runs:
     - name: Check user permission
       if: inputs.permissions != 'any' && steps.mentions.outputs.skip != 'true'
       uses: actions/github-script@v7
+      env:
+        REQUIRED_PERMISSION: ${{ inputs.permissions }}
       with:
         script: |
           // Retry transient GitHub API errors (5xx) with exponential backoff
@@ -109,7 +111,7 @@ runs:
             }
           }
 
-          const requiredPermission = '${{ inputs.permissions }}';
+          const requiredPermission = process.env.REQUIRED_PERMISSION;
           const actor = context.actor;
 
           const { data: permissionLevel } = await withRetry(
@@ -213,11 +215,11 @@ runs:
           }
 
     - name: Setup bun
-      if: steps.mentions.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true'
       uses: oven-sh/setup-bun@v2
 
     - name: Ensure workflow exists
-      if: steps.mentions.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true'
       id: setup
       shell: bash
       env:
@@ -226,29 +228,25 @@ runs:
         GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
         ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        PR_URL: ${{ github.event.pull_request.url || github.event.issue.pull_request.url || '' }}
+        SETUP_GH_TOKEN: ${{ github.token }}
+        FORKS: ${{ inputs.forks }}
       run: bun run ${{ github.action_path }}/script/setup.ts
 
     - name: Get opencode version
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
       id: version
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
         OPENCODE_DEV: ${{ inputs.opencode_dev }}
-      run: |
-        if [ "$OPENCODE_DEV" = "true" ]; then
-          # Get latest commit SHA from dev branch
-          VERSION=$(gh api repos/sst/opencode/commits/dev --jq '.sha' 2>/dev/null | head -c 7 || echo "dev")
-          echo "version=dev-${VERSION}" >> $GITHUB_OUTPUT
-          echo "dev=true" >> $GITHUB_OUTPUT
-        else
-          VERSION=$(gh api repos/sst/opencode/releases/latest --jq '.tag_name' 2>/dev/null || echo "latest")
-          echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
-          echo "dev=false" >> $GITHUB_OUTPUT
-        fi
+      run: bun run ${{ github.action_path }}/script/version.ts
 
     - name: Cache opencode
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.version.outputs.cacheable == 'true'
       id: cache
       uses: actions/cache@v4
       with:
@@ -256,70 +254,78 @@ runs:
         key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
 
     - name: Install opencode
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       env:
         OPENCODE_DEV: ${{ steps.version.outputs.dev }}
       run: |
+        set -euo pipefail
         if [ "$OPENCODE_DEV" = "true" ]; then
-          curl -fsSL https://opencode.ai/install | bash -s -- --dev
+          curl -fsSL --connect-timeout 5 --max-time 60 https://opencode.ai/install -o /tmp/opencode-install.sh
+          bash /tmp/opencode-install.sh --dev
         else
-          curl -fsSL https://opencode.ai/install | bash
+          curl -fsSL --connect-timeout 5 --max-time 60 https://opencode.ai/install -o /tmp/opencode-install.sh
+          bash /tmp/opencode-install.sh
         fi
 
     - name: Add opencode to PATH
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
       shell: bash
       run: echo "$HOME/.opencode/bin" >> $GITHUB_PATH
 
     - name: Configure Git
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
       shell: bash
       run: |
         git config --global user.name "ask-bonk[bot]"
         git config --global user.email "ask-bonk[bot]@users.noreply.github.com"
 
+    - name: Build prompt
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      id: prompt
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
+        REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.issue.pull_request.url && github.event.issue.number || github.event.pull_request.number || '' }}
+        GH_TOKEN: ${{ github.token }}
+        PR_URL: ${{ github.event.pull_request.url || github.event.issue.pull_request.url || '' }}
+        USER_PROMPT: ${{ inputs.prompt }}
+        ACTION_PATH: ${{ github.action_path }}
+        FORKS: ${{ inputs.forks }}
+        ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: bun run ${{ github.action_path }}/script/prompt.ts
+
     - name: Exchange OIDC token for GitHub App token
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.prompt.outputs.skip != 'true' && steps.prompt.outputs.is_fork != 'true'
       id: oidc
       shell: bash
       env:
+        OIDC_BASE_URL: ${{ inputs.oidc_base_url }}
         FALLBACK_TOKEN: ${{ github.token }}
+      run: bun run ${{ github.action_path }}/script/oidc-exchange.ts
+
+    - name: Require OIDC for non-fork runs
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.prompt.outputs.skip != 'true'
+      shell: bash
       run: |
-        # Get GitHub Actions OIDC token
-        if [ -z "$ACTIONS_ID_TOKEN_REQUEST_URL" ] || [ -z "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ]; then
-          echo "::warning::OIDC credentials not available (expected for fork PRs). Falling back to github.token."
-          echo "::add-mask::$FALLBACK_TOKEN"
-          echo "GH_TOKEN=$FALLBACK_TOKEN" >> $GITHUB_ENV
-          echo "oidc_failed=true" >> $GITHUB_OUTPUT
-          exit 0
+        # prompt.ts fails closed on fork detection failure, so if we're here,
+        # is_fork is a definitive true/false. If OIDC failed for a non-fork
+        # run, that's always a hard failure.
+        if [ "${OIDC_FAILED}" = "true" ] && [ "${IS_FORK}" != "true" ]; then
+          echo "::error::OIDC token exchange failed for non-fork run. Ensure id-token: write is configured."
+          exit 1
         fi
+      env:
+        OIDC_FAILED: ${{ steps.oidc.outputs.oidc_failed }}
+        IS_FORK: ${{ steps.prompt.outputs.is_fork }}
 
-        OIDC_TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-          "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=opencode-github-action" | jq -r '.value')
-
-        # Exchange for GitHub App installation token via Bonk's OIDC endpoint
-        RESPONSE=$(curl -s -X POST "${{ inputs.oidc_base_url }}/exchange_github_app_token" \
-          -H "Authorization: Bearer $OIDC_TOKEN" \
-          -H "Content-Type: application/json")
-
-        APP_TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty')
-
-        if [ -z "$APP_TOKEN" ]; then
-          echo "::warning::Failed to exchange OIDC token: $(echo "$RESPONSE" | jq -r '.error // "Unknown error"'). Falling back to github.token."
-          echo "::add-mask::$FALLBACK_TOKEN"
-          echo "GH_TOKEN=$FALLBACK_TOKEN" >> $GITHUB_ENV
-          echo "oidc_failed=true" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # Mask the token in logs and export for subsequent steps
-        echo "::add-mask::$APP_TOKEN"
-        echo "GH_TOKEN=$APP_TOKEN" >> $GITHUB_ENV
-        echo "oidc_failed=false" >> $GITHUB_OUTPUT
 
     - name: Track Bonk run
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.oidc.outputs.oidc_failed != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.prompt.outputs.skip != 'true' && steps.prompt.outputs.is_fork != 'true' && steps.oidc.outputs.oidc_failed != 'true'
       shell: bash
       env:
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}
@@ -336,31 +342,25 @@ runs:
         ISSUE_CREATED_AT: ${{ github.event.issue.created_at || github.event.pull_request.created_at }}
       run: bun run ${{ github.action_path }}/script/track.ts
 
-    - name: Build prompt
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
-      id: prompt
-      shell: bash
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-        PR_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        REPOSITORY: ${{ github.repository }}
-        PR_NUMBER: ${{ github.event.issue.pull_request.url && github.event.issue.number || github.event.pull_request.number || '' }}
-        GH_TOKEN: ${{ github.token }}
-        USER_PROMPT: ${{ inputs.prompt }}
-        ACTION_PATH: ${{ github.action_path }}
-        FORKS: ${{ inputs.forks }}
-        ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      run: bun run ${{ github.action_path }}/script/prompt.ts
-
     - name: Run opencode
-      if: steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.prompt.outputs.skip != 'true'
+      if: success() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.prompt.outputs.skip != 'true'
       id: opencode
       shell: bash
       run: |
         set +e
-        opencode github run
+        # Tell OpenCode to use the token directly instead of its own OIDC flow.
+        # For forks, use the runner token (read-only). For non-fork runs, the
+        # "Require OIDC" step guarantees OIDC succeeded, so GH_TOKEN is the app token.
+        # For non-fork runs, GH_TOKEN is the app token written to GITHUB_ENV by
+        # the OIDC exchange step (not declared in env: below — it's a side-channel).
+        export USE_GITHUB_TOKEN=true
+        if [ "${IS_FORK}" = "true" ]; then
+          export GITHUB_TOKEN="${RUNNER_GITHUB_TOKEN}"
+          export GH_TOKEN="${RUNNER_GITHUB_TOKEN}"
+        else
+          export GITHUB_TOKEN="${GH_TOKEN}"
+        fi
+        timeout 45m opencode github run
         EXIT_CODE=$?
         echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
         exit $EXIT_CODE
@@ -371,13 +371,11 @@ runs:
         SHARE: false
         MENTIONS: ${{ inputs.mentions }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}
-        # When OIDC is unavailable (fork PRs), tell OpenCode to use the
-        # fallback GH_TOKEN directly instead of attempting its own OIDC flow.
-        USE_GITHUB_TOKEN: ${{ steps.oidc.outputs.oidc_failed == 'true' && 'true' || '' }}
-        GITHUB_TOKEN: ${{ steps.oidc.outputs.oidc_failed == 'true' && env.GH_TOKEN || '' }}
+        IS_FORK: ${{ steps.prompt.outputs.is_fork }}
+        RUNNER_GITHUB_TOKEN: ${{ github.token }}
 
     - name: Finalize Bonk run
-      if: always() && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true'
+      if: always() && steps.setup.outcome == 'success' && steps.mentions.outputs.skip != 'true' && steps.setup.outputs.skip != 'true' && steps.prompt.outcome == 'success' && steps.prompt.outputs.skip != 'true' && steps.prompt.outputs.is_fork != 'true'
       shell: bash
       env:
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}

--- a/github/script/finalize.ts
+++ b/github/script/finalize.ts
@@ -2,6 +2,7 @@
 // Called by the GitHub Action after OpenCode completes (with if: always())
 
 import { getContext, getOidcToken, getApiBaseUrl, core } from "./context";
+import { fetchWithRetry } from "./http";
 
 async function main() {
   const context = getContext();
@@ -20,7 +21,7 @@ async function main() {
   const apiBase = getApiBaseUrl();
 
   try {
-    const response = await fetch(`${apiBase}/api/github/track`, {
+    const response = await fetchWithRetry(`${apiBase}/api/github/track`, {
       method: "PUT",
       headers: {
         Authorization: `Bearer ${oidcToken}`,

--- a/github/script/http.ts
+++ b/github/script/http.ts
@@ -1,0 +1,78 @@
+const DEFAULT_TIMEOUT_MS = 4000;
+const DEFAULT_RETRIES = 2;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 30000;
+
+interface RetryOptions {
+  timeoutMs?: number;
+  retries?: number;
+  baseDelayMs?: number;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientStatus(response: Response): boolean {
+  if (response.status >= 500 || response.status === 429) return true;
+  if (response.status !== 403) return false;
+  const retryAfter = response.headers.get("retry-after");
+  const remaining = response.headers.get("x-ratelimit-remaining");
+  return Boolean(retryAfter) || remaining === "0";
+}
+
+// Parse the retry-after header as integer seconds (the format GitHub uses),
+// capped to MAX_RETRY_DELAY_MS. Returns 0 if the header is missing or unparseable.
+// Does not handle HTTP-date format since the GitHub API only uses integers.
+function parseRetryAfterMs(response: Response): number {
+  const header = response.headers.get("retry-after");
+  if (!header) return 0;
+  const seconds = parseInt(header, 10);
+  if (isNaN(seconds) || seconds <= 0) return 0;
+  return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  retryOptions: RetryOptions = {},
+): Promise<Response> {
+  const timeoutMs = retryOptions.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retries = retryOptions.retries ?? DEFAULT_RETRIES;
+  const baseDelayMs = retryOptions.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      const response = await fetchWithTimeout(url, options, timeoutMs);
+      if (isTransientStatus(response) && attempt < retries) {
+        const retryAfterMs = parseRetryAfterMs(response);
+        await sleep(Math.max(retryAfterMs, baseDelayMs * (attempt + 1)));
+        continue;
+      }
+      return response;
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await sleep(baseDelayMs * (attempt + 1));
+        continue;
+      }
+    }
+  }
+
+  throw lastError ?? new Error("fetch failed after retries");
+}

--- a/github/script/oidc-exchange.ts
+++ b/github/script/oidc-exchange.ts
@@ -1,0 +1,105 @@
+// Exchange a GitHub Actions OIDC token for a GitHub App installation token
+// via Bonk's OIDC endpoint. Outputs the token (masked) to GH_TOKEN env var,
+// or falls back to github.token when OIDC credentials aren't available.
+
+import { getOidcToken, getApiBaseUrl, core } from "./context";
+import { fetchWithRetry } from "./http";
+
+async function main() {
+  const fallbackToken = process.env.FALLBACK_TOKEN || "";
+  const oidcUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+  const oidcToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+
+  if (!oidcUrl || !oidcToken) {
+    core.warning("OIDC credentials not available (expected for fork PRs). Falling back to github.token.");
+    maskValue(fallbackToken);
+    appendToGithubEnv("GH_TOKEN", fallbackToken);
+    core.setOutput("oidc_failed", "true");
+    return;
+  }
+
+  // Get the OIDC token from GitHub Actions
+  let actionOidcToken: string;
+  try {
+    actionOidcToken = await getOidcToken();
+  } catch (error) {
+    core.setFailed(`Failed to get OIDC token: ${error}`);
+    return;
+  }
+
+  // Exchange for a GitHub App installation token via Bonk's endpoint
+  const rawOidcBaseUrl = process.env.OIDC_BASE_URL;
+  if (!rawOidcBaseUrl) {
+    core.setFailed("OIDC_BASE_URL not set");
+    return;
+  }
+  const oidcBaseUrl = rawOidcBaseUrl.replace(/\/+$/, "");
+
+  let appToken: string;
+  try {
+    // Longer timeout: this is a multi-hop request (runner → worker → GitHub API)
+    const resp = await fetchWithRetry(
+      `${oidcBaseUrl}/exchange_github_app_token`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${actionOidcToken}`,
+          "Content-Type": "application/json",
+        },
+      },
+      { timeoutMs: 10000 },
+    );
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      let errorMessage = "Unknown error";
+      try {
+        const data = JSON.parse(text) as { error?: string };
+        errorMessage = data.error || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      core.setFailed(`Failed to exchange OIDC token: ${errorMessage}`);
+      return;
+    }
+
+    const data = (await resp.json()) as { token?: string };
+    if (!data.token) {
+      core.setFailed("OIDC token exchange response missing token.");
+      return;
+    }
+    appToken = data.token;
+  } catch (error) {
+    core.setFailed(`OIDC token exchange failed: ${error}`);
+    return;
+  }
+
+  maskValue(appToken);
+  appendToGithubEnv("GH_TOKEN", appToken);
+  core.setOutput("oidc_failed", "false");
+}
+
+function maskValue(value: string): void {
+  if (value) {
+    console.log(`::add-mask::${value}`);
+  }
+}
+
+function appendToGithubEnv(name: string, value: string): void {
+  const envFile = process.env.GITHUB_ENV;
+  if (!envFile) {
+    core.warning("GITHUB_ENV not set; cannot export environment variable");
+    return;
+  }
+  const fs = require("fs");
+  if (value.includes("\n")) {
+    const delimiter = `BONK_${crypto.randomUUID().replace(/-/g, "")}`;
+    fs.appendFileSync(envFile, `${name}<<${delimiter}\n${value}\n${delimiter}\n`);
+  } else {
+    fs.appendFileSync(envFile, `${name}=${value}\n`);
+  }
+}
+
+main().catch((error) => {
+  core.setFailed(`Unexpected error: ${error}`);
+});

--- a/github/script/prompt.ts
+++ b/github/script/prompt.ts
@@ -6,7 +6,8 @@
 // When a fork is detected and forks input is "false": posts a comment explaining
 // fork PRs aren't supported by this workflow, and sets skip=true to halt the run.
 
-import { core } from "./context";
+import { core, detectForkFromPR } from "./context";
+import { fetchWithRetry } from "./http";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -15,51 +16,80 @@ interface ForkDetectionResult {
   // When we fetch PR data during detection (issue_comment events), cache it so
   // resolveHeadSha() can reuse it instead of making a duplicate API call.
   headSha?: string;
+  detectionFailed?: boolean;
+}
+
+// Verify that the token used for fork runs is read-only.
+async function assertForkTokenSafety(repository: string, ghToken: string): Promise<void> {
+  let resp: Response;
+  try {
+    resp = await fetchWithRetry(
+      `https://api.github.com/repos/${repository}`,
+      {
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: "application/vnd.github+json",
+        },
+      },
+    );
+  } catch (error) {
+    core.setFailed(`Fork token safety check failed: ${error}`);
+    return;
+  }
+
+  if (!resp.ok) {
+    core.setFailed(`Fork token safety check failed (${resp.status}); refusing to proceed.`);
+    return;
+  }
+  const data = (await resp.json()) as { permissions?: { push?: boolean; admin?: boolean } };
+  if (data.permissions?.push || data.permissions?.admin) {
+    core.setFailed(
+      "Fork runs require read-only repository permissions. Remove contents: write from the workflow permissions.",
+    );
+    return;
+  }
 }
 
 // Detect whether the current event is from a fork PR.
-// For pull_request, pull_request_review_comment, and pull_request_review events,
-// head/base repo are available directly in the event payload via env vars.
-// For issue_comment events on PRs, we fetch PR data via the GitHub API since the
-// issue_comment payload doesn't include full PR repo info.
+// Uses the shared detectForkFromPR helper for env-var comparison and API fallback.
+// For issue_comment events, constructs a PR URL from REPOSITORY + PR_NUMBER.
 async function detectFork(): Promise<ForkDetectionResult> {
   const eventName = process.env.EVENT_NAME;
-  const headRepo = process.env.PR_HEAD_REPO;
-  const baseRepo = process.env.PR_BASE_REPO;
-  const repository = process.env.REPOSITORY;
-  const prNumber = process.env.PR_NUMBER;
   const ghToken = process.env.GH_TOKEN;
 
   switch (eventName) {
     case "pull_request":
     case "pull_request_review_comment":
-    case "pull_request_review":
-      // A null/missing head repo means the fork was deleted — still a fork PR.
-      return { isFork: !headRepo || headRepo !== baseRepo };
-
-    case "issue_comment":
-      // Only check if this is a comment on a PR (PR_NUMBER is set)
-      if (!prNumber || !repository || !ghToken) return { isFork: false };
-      try {
-        const resp = await fetch(`https://api.github.com/repos/${repository}/pulls/${prNumber}`, {
-          headers: {
-            Authorization: `Bearer ${ghToken}`,
-            Accept: "application/vnd.github+json",
-          },
-        });
-        if (!resp.ok) return { isFork: false };
-        const pr = (await resp.json()) as {
-          head?: { repo?: { full_name?: string }; sha?: string };
-          base?: { repo?: { full_name?: string } };
-        };
-        const head = pr.head?.repo?.full_name;
-        const base = pr.base?.repo?.full_name;
-        // A null/missing head repo means the fork was deleted — still a fork PR.
-        const isFork = !head || head !== base;
-        return { isFork, headSha: pr.head?.sha };
-      } catch {
-        return { isFork: false };
+    case "pull_request_review": {
+      const result = await detectForkFromPR(
+        process.env.PR_HEAD_REPO,
+        process.env.PR_BASE_REPO,
+        process.env.PR_URL,
+        ghToken,
+      );
+      if (!result) {
+        core.warning("Fork detection failed for PR event");
+        return { isFork: false, detectionFailed: true };
       }
+      return result;
+    }
+
+    case "issue_comment": {
+      const prNumber = process.env.PR_NUMBER;
+      const repository = process.env.REPOSITORY;
+      if (!prNumber || !repository) return { isFork: false };
+      if (!ghToken) {
+        core.warning("Fork detection failed: missing GH_TOKEN");
+        return { isFork: false, detectionFailed: true };
+      }
+      const prUrl = `https://api.github.com/repos/${repository}/pulls/${prNumber}`;
+      const result = await detectForkFromPR(undefined, undefined, prUrl, ghToken);
+      if (!result) {
+        core.warning("Fork detection failed for issue_comment event");
+        return { isFork: false, detectionFailed: true };
+      }
+      return result;
+    }
 
     default:
       return { isFork: false };
@@ -71,7 +101,7 @@ async function detectFork(): Promise<ForkDetectionResult> {
 // Deduplicates using an HTML comment marker to avoid spamming on repeated mentions.
 const FORK_SKIP_MARKER = "<!-- bonk-fork-skip -->";
 
-async function commentForkSkipped(): Promise<void> {
+async function commentForkSkipped(reason?: string): Promise<void> {
   const repository = process.env.REPOSITORY;
   const ghToken = process.env.GH_TOKEN;
   // ISSUE_NUMBER covers both PR events and issue_comment events on PRs
@@ -84,47 +114,61 @@ async function commentForkSkipped(): Promise<void> {
 
   // Check if we already posted this comment to avoid duplicate spam
   try {
-    const existingResp = await fetch(
-      `https://api.github.com/repos/${repository}/issues/${issueNumber}/comments?per_page=30&direction=desc`,
-      {
-        headers: {
-          Authorization: `Bearer ${ghToken}`,
-          Accept: "application/vnd.github+json",
+    let page = 1;
+    while (page <= 3) {
+      const existingResp = await fetchWithRetry(
+        `https://api.github.com/repos/${repository}/issues/${issueNumber}/comments?per_page=100&direction=desc&page=${page}`,
+        {
+          headers: {
+            Authorization: `Bearer ${ghToken}`,
+            Accept: "application/vnd.github+json",
+          },
         },
-      },
-    );
-    if (existingResp.ok) {
+      );
+      if (!existingResp.ok) {
+        break;
+      }
       const comments = (await existingResp.json()) as Array<{ body?: string }>;
       if (comments.some((c) => c.body?.includes(FORK_SKIP_MARKER))) {
         core.info("Fork skip comment already exists, skipping duplicate.");
         return;
       }
+      if (comments.length < 100) {
+        break;
+      }
+      page += 1;
     }
   } catch {
     // If the dedup check fails, proceed to post anyway
   }
 
+  const reasonLine = reason ? `\n> ${reason}` : "";
   const body =
     `${FORK_SKIP_MARKER}\n` +
     "> [!NOTE]\n" +
     "> This workflow is configured to skip pull requests from forks. " +
     "Fork PRs can be reviewed manually, or the workflow can be updated to " +
-    "handle forks in comment-only mode by setting `forks: true` in the action configuration.";
+    "handle forks in comment-only mode by setting `forks: true` in the action configuration." +
+    reasonLine;
 
-  const resp = await fetch(
-    `https://api.github.com/repos/${repository}/issues/${issueNumber}/comments`,
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${ghToken}`,
-        Accept: "application/vnd.github+json",
+  try {
+    const resp = await fetchWithRetry(
+      `https://api.github.com/repos/${repository}/issues/${issueNumber}/comments`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: "application/vnd.github+json",
+        },
+        body: JSON.stringify({ body }),
       },
-      body: JSON.stringify({ body }),
-    },
-  );
+    );
 
-  if (!resp.ok) {
-    core.warning(`Failed to post fork skip comment: ${resp.status} ${resp.statusText}`);
+    if (!resp.ok) {
+      core.warning(`Failed to post fork skip comment: ${resp.status} ${resp.statusText}`);
+    }
+  } catch (error) {
+    core.warning(`Failed to post fork skip comment: ${error}`);
   }
 }
 
@@ -132,7 +176,12 @@ async function commentForkSkipped(): Promise<void> {
 // ISSUE_NUMBER is set for both issue_comment and pull_request_review events.
 // PR_NUMBER is set for issue_comment events on PRs (from action.yml).
 function resolvePRNumber(): string {
-  return process.env.ISSUE_NUMBER || process.env.PR_NUMBER || "";
+  const direct = process.env.ISSUE_NUMBER || process.env.PR_NUMBER;
+  if (direct) return direct;
+
+  const prUrl = process.env.PR_URL || "";
+  const match = prUrl.match(/\/pulls\/(\d+)$/);
+  return match?.[1] || "";
 }
 
 // Resolve the HEAD SHA for the PR. Checks, in order:
@@ -153,12 +202,15 @@ async function resolveHeadSha(
   if (!prNumber || !repository || !ghToken) return "";
 
   try {
-    const resp = await fetch(`https://api.github.com/repos/${repository}/pulls/${prNumber}`, {
-      headers: {
-        Authorization: `Bearer ${ghToken}`,
-        Accept: "application/vnd.github+json",
+    const resp = await fetchWithRetry(
+      `https://api.github.com/repos/${repository}/pulls/${prNumber}`,
+      {
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: "application/vnd.github+json",
+        },
       },
-    });
+    );
     if (!resp.ok) return "";
     const pr = (await resp.json()) as { head?: { sha?: string } };
     return pr.head?.sha || "";
@@ -171,27 +223,47 @@ async function main() {
   const detection = await detectFork();
   core.setOutput("is_fork", String(detection.isFork));
 
-  if (detection.isFork) {
-    const forksEnabled = process.env.FORKS !== "false";
+  const forksEnabled = process.env.FORKS !== "false";
+  if (detection.detectionFailed) {
+    core.setFailed("Fork status could not be verified; refusing to proceed.");
+    return;
+  }
 
-    if (!forksEnabled) {
-      core.info("PR is from a fork and forks input is disabled. Skipping.");
-      await commentForkSkipped();
-      core.setOutput("skip", "true");
+  // detectionFailed already caused an early exit above, so this is just isFork.
+  const commentOnly = detection.isFork;
+
+  if (detection.isFork && process.env.EVENT_NAME === "pull_request") {
+    core.warning("Fork PRs triggered by pull_request events cannot post comments; skipping.");
+    core.setOutput("skip", "true");
+    return;
+  }
+
+  if (detection.isFork && !forksEnabled) {
+    core.info("PR is from a fork and forks input is disabled. Skipping.");
+    await commentForkSkipped();
+    core.setOutput("skip", "true");
+    return;
+  }
+
+  // Token safety check only runs when we're about to proceed with a fork run
+  if (commentOnly) {
+    const repository = process.env.REPOSITORY || "";
+    const ghToken = process.env.GH_TOKEN || "";
+    if (!repository || !ghToken) {
+      core.setFailed("Fork token safety check missing REPOSITORY or GH_TOKEN; refusing to proceed.");
       return;
     }
-
+    await assertForkTokenSafety(repository, ghToken);
     core.info("PR is from a fork. Agent will run in comment-only mode.");
   }
 
   // Build prompt: fork guidance (if fork) + user prompt (if provided)
   const parts: string[] = [];
 
-  if (detection.isFork) {
+  if (commentOnly) {
     const actionPath = process.env.ACTION_PATH;
     if (!actionPath) {
-      core.setFailed("ACTION_PATH not set");
-      return;
+      core.warning("ACTION_PATH not set, continuing without fork guidance");
     }
 
     // Resolve concrete values for the fork guidance template.
@@ -203,17 +275,33 @@ async function main() {
     const headSha = await resolveHeadSha(prNumber, repository, detection.headSha);
 
     if (!prNumber || !owner || !repo) {
-      core.setFailed("Cannot determine PR number or repository for fork guidance");
-      return;
+      core.warning("Cannot determine PR number or repository for fork guidance; using minimal guidance");
+      parts.push("This PR is from a fork. You are in comment-only mode. Do not attempt git write operations.");
+    } else if (!actionPath) {
+      parts.push(
+        `This PR is from a fork. You are in comment-only mode for PR #${prNumber} in ${owner}/${repo}. Do not attempt git write operations.`,
+      );
+    } else {
+      let guidance: string;
+      try {
+        guidance = readFileSync(join(actionPath, "fork_guidance.md"), "utf-8");
+      } catch (error) {
+        core.warning(`Could not read fork_guidance.md, using minimal guidance: ${error}`);
+        guidance =
+          "This PR is from a fork. You are in comment-only mode for PR #{{PR_NUMBER}} in {{OWNER}}/{{REPO}}. Do not attempt git write operations.";
+      }
+
+      if (!headSha) {
+        core.warning("Could not resolve HEAD SHA for fork PR; inline review comments may fail");
+      }
+
+      guidance = guidance.replace(/\{\{PR_NUMBER\}\}/g, prNumber);
+      guidance = guidance.replace(/\{\{OWNER\}\}/g, owner);
+      guidance = guidance.replace(/\{\{REPO\}\}/g, repo);
+      guidance = guidance.replace(/\{\{HEAD_SHA\}\}/g, headSha || "UNKNOWN");
+
+      parts.push(guidance.trim());
     }
-
-    let guidance = readFileSync(join(actionPath, "fork_guidance.md"), "utf-8");
-    guidance = guidance.replace(/\{\{PR_NUMBER\}\}/g, prNumber);
-    guidance = guidance.replace(/\{\{OWNER\}\}/g, owner);
-    guidance = guidance.replace(/\{\{REPO\}\}/g, repo);
-    guidance = guidance.replace(/\{\{HEAD_SHA\}\}/g, headSha || "UNKNOWN");
-
-    parts.push(guidance.trim());
   }
 
   const userPrompt = process.env.USER_PROMPT;

--- a/github/script/setup.ts
+++ b/github/script/setup.ts
@@ -1,7 +1,8 @@
 // Check if workflow file exists, create PR if not
 // Called by the GitHub Action before running OpenCode
 
-import { getContext, getOidcToken, getApiBaseUrl, core } from "./context";
+import { getContext, getOidcToken, getApiBaseUrl, detectForkFromPR, core } from "./context";
+import { fetchWithRetry } from "./http";
 
 interface SetupResponse {
   exists: boolean;
@@ -9,13 +10,34 @@ interface SetupResponse {
   error?: string;
 }
 
+async function detectForkInSetup(): Promise<boolean | null> {
+  const result = await detectForkFromPR(
+    process.env.PR_HEAD_REPO,
+    process.env.PR_BASE_REPO,
+    process.env.PR_URL,
+    process.env.SETUP_GH_TOKEN,
+  );
+  return result?.isFork ?? null;
+}
+
 async function main() {
   const context = getContext();
   const { owner, repo } = context.repo;
   const issueNumber = context.issue?.number;
   const defaultBranch = context.defaultBranch;
+  const eventName = process.env.EVENT_NAME || "";
 
   if (!issueNumber) {
+    if (
+      eventName === "pull_request" ||
+      eventName === "pull_request_review" ||
+      eventName === "pull_request_review_comment" ||
+      eventName === "issue_comment" ||
+      eventName === "issues"
+    ) {
+      core.setFailed("No issue number found for PR/issue event; cannot run setup check");
+      return;
+    }
     core.info("No issue number found, skipping setup check");
     core.setOutput("skip", "false");
     return;
@@ -29,31 +51,48 @@ async function main() {
   try {
     oidcToken = await getOidcToken();
   } catch (error) {
-    const oidcAvailable = !!process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
+    const oidcAvailable =
+      !!process.env.ACTIONS_ID_TOKEN_REQUEST_URL && !!process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
     if (oidcAvailable) {
-      core.warning(`OIDC token exchange failed unexpectedly, skipping setup check: ${error}`);
-    } else {
-      core.warning(`OIDC not available (expected for fork PRs), skipping setup check`);
+      core.setFailed(`OIDC token exchange failed unexpectedly: ${error}`);
+      return;
     }
-    core.setOutput("skip", "false");
+    const isFork = await detectForkInSetup();
+    if (isFork === true) {
+      core.warning("OIDC not available for fork PR, skipping setup check");
+      core.setOutput("skip", "false");
+      return;
+    }
+    if (isFork === false) {
+      core.setFailed("OIDC not available for non-fork PR. Ensure id-token: write is configured.");
+      return;
+    }
+    // isFork === null: fork status unknown. Fail closed.
+    core.setFailed("OIDC not available and fork status could not be determined.");
     return;
   }
 
   const apiBase = getApiBaseUrl();
 
-  const response = await fetch(`${apiBase}/api/github/setup`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${oidcToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      owner,
-      repo,
-      issue_number: issueNumber,
-      default_branch: defaultBranch,
-    }),
-  });
+  let response: Response;
+  try {
+    response = await fetchWithRetry(`${apiBase}/api/github/setup`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${oidcToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        default_branch: defaultBranch,
+      }),
+    });
+  } catch (error) {
+    core.setFailed(`Setup request failed: ${error}`);
+    return;
+  }
 
   if (!response.ok) {
     const text = await response.text();

--- a/github/script/version.ts
+++ b/github/script/version.ts
@@ -1,0 +1,67 @@
+// Resolve the opencode version for cache keying.
+// Uses the GitHub API to fetch the latest release tag or dev commit SHA.
+
+import { core } from "./context";
+import { fetchWithRetry } from "./http";
+
+const OPENCODE_REPO = "anomalyco/opencode";
+
+async function main() {
+  const isDev = process.env.OPENCODE_DEV === "true";
+  const ghToken = process.env.GH_TOKEN || "";
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+  };
+  if (ghToken) {
+    headers.Authorization = `Bearer ${ghToken}`;
+  }
+
+  if (isDev) {
+    let version = "dev";
+    try {
+      const resp = await fetchWithRetry(
+        `https://api.github.com/repos/${OPENCODE_REPO}/commits/dev`,
+        { headers },
+      );
+      if (resp.ok) {
+        const data = (await resp.json()) as { sha?: string };
+        if (data.sha) {
+          version = data.sha.slice(0, 7);
+        }
+      }
+    } catch {
+      // Fall back to "dev" if the API is unavailable
+    }
+    core.setOutput("version", `dev-${version}`);
+    core.setOutput("dev", "true");
+    // "dev" is a valid fallback — still busts cache on each run
+    core.setOutput("cacheable", "true");
+  } else {
+    let version = "latest";
+    try {
+      const resp = await fetchWithRetry(
+        `https://api.github.com/repos/${OPENCODE_REPO}/releases/latest`,
+        { headers },
+      );
+      if (resp.ok) {
+        const data = (await resp.json()) as { tag_name?: string };
+        if (data.tag_name) {
+          version = data.tag_name;
+        }
+      }
+    } catch {
+      // Fall back to "latest" if the API is unavailable
+    }
+    core.setOutput("version", version);
+    core.setOutput("dev", "false");
+    // Skip caching when version is "latest" — the key never busts on new releases
+    core.setOutput("cacheable", version !== "latest" ? "true" : "false");
+  }
+}
+
+main().catch((error) => {
+  core.warning(`Failed to get opencode version: ${error}`);
+  core.setOutput("version", process.env.OPENCODE_DEV === "true" ? "dev-dev" : "latest");
+  core.setOutput("dev", process.env.OPENCODE_DEV === "true" ? "true" : "false");
+  core.setOutput("cacheable", "false");
+});


### PR DESCRIPTION
OpenCode's `opencode github run` crashed when OIDC credentials were unavailable (fork PRs, missing `id-token: write`). The OIDC exchange and version lookup were fragile shell scripts with inline retry loops and jq/node fallback chains. Fork detection silently assumed non-fork on API failures, and the action continued running after permission check failures.

- fail-closed fork detection: action refuses to proceed if fork status can't be verified (API failure, missing env vars, rate limits). fork PRs run in comment-only mode with a read-only runner token, verified by `assertForkTokenSafety` before any work starts
- move OIDC exchange and version lookup from shell to TypeScript (`oidc-exchange.ts`, `version.ts`), removing curl/jq/node fallback complexity from action.yml
- shared `fetchWithRetry` in `http.ts` for all GitHub API calls: 3 attempts, 4s timeout per attempt, backoff that respects `retry-after` header (capped to 30s). covers OIDC, fork detection, setup, tracking, finalize, version lookup, token safety, and comment dedup
- tracking and finalize failures are now warnings instead of fatal — they're observability, not core functionality
- action.yml steps gated with `success()` so permission check failures stop downstream steps. finalize requires prompt success to avoid finalizing runs that never started
- opencode step uses simple if/else on `IS_FORK` for token selection — the "Require OIDC" step guarantees non-fork runs have a valid app token
- fix `sst/opencode` -> `anomalyco/opencode` repo reference in version lookup
- heredoc delimiter handling in `appendToGithubEnv` to prevent potential `GITHUB_ENV` corruption

```
github/script/http.ts           — shared fetchWithRetry/fetchWithTimeout
github/script/oidc-exchange.ts  — OIDC token exchange (was inline shell)
github/script/version.ts        — opencode version lookup (was inline shell)
github/script/prompt.ts         — fork detection, token safety, prompt construction
github/script/setup.ts          — OIDC availability, fork detection at setup time
github/script/track.ts          — warning-only tracking
github/script/finalize.ts       — warning-only finalize with retry
github/script/context.ts        — OIDC token fetch uses shared retry
github/action.yml               — declarative step definitions calling .ts scripts
```

`bun run tsc --noEmit` and `bun run test` pass (67 tests).