### PR TITLE
add /version route with build-time git tag and commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "deploy": "wrangler deploy",
+    "deploy": "wrangler deploy --define __VERSION__:\"\\\"$(git describe --tags --always)\\\"\" --define __COMMIT__:\"\\\"$(git rev-parse --short HEAD)\\\"\"",
     "dev": "wrangler dev",
     "test": "vitest",
     "cf-typegen": "wrangler types",

--- a/src/hbs.d.ts
+++ b/src/hbs.d.ts
@@ -1,3 +1,7 @@
+// Build-time constants injected via wrangler --define flags (see package.json deploy script)
+declare const __VERSION__: string;
+declare const __COMMIT__: string;
+
 declare module "*.hbs" {
   const content: string;
   export default content;

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,9 @@ const app = new Hono<{ Bindings: Env }>();
 
 app.get("/", (c) => c.redirect(GITHUB_REPO_URL, 302));
 app.get("/health", (c) => c.text("OK"));
+app.get("/version", (c) =>
+  c.json({ version: __VERSION__, commit: __COMMIT__ }),
+);
 
 // Stats endpoints - public dashboards for webhook analytics
 const stats = new Hono<{ Bindings: Env }>();

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,11 @@
     },
   ],
   "compatibility_flags": ["nodejs_compat"],
+  // Build-time constants replaced by esbuild. Deploy script overrides with real values.
+  "define": {
+    "__VERSION__": "\"dev\"",
+    "__COMMIT__": "\"unknown\"",
+  },
   "observability": {
     "enabled": true,
     "traces": {

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -4,6 +4,10 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-12-11",
   "compatibility_flags": ["nodejs_compat"],
+  "define": {
+    "__VERSION__": "\"test\"",
+    "__COMMIT__": "\"abc1234\"",
+  },
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
Adds a `/version` endpoint so you can validate what Bonk was built from.

The version and commit are injected at build time via wrangler's esbuild `define` — no runtime overhead, no env vars. Defaults live in `wrangler.jsonc`; only the deploy script overrides them with real git values.

- `GET /version` returns `{ version, commit }` (public, like `/health`)
- `wrangler.jsonc` defines `__VERSION__` and `__COMMIT__` with dev-safe defaults (`"dev"`, `"unknown"`)
- deploy script passes `--define` flags with `git describe --tags --always` and `git rev-parse --short HEAD`
- test config gets its own static values for determinism

```
$ curl https://bonk.example.com/version
{"version":"v0.3.3","commit":"67602c6"}
```

Types, lint, and all 67 tests pass.