### PR TITLE
update compatibility_date to 2026-02-14

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "ask-bonk",
   "main": "src/index.ts",
-  "compatibility_date": "2025-12-11",
+  "compatibility_date": "2026-02-14",
   "rules": [
     {
       "type": "Text",

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "ask-bonk",
   "main": "src/index.ts",
-  "compatibility_date": "2025-12-11",
+  "compatibility_date": "2026-02-14",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
     "enabled": true,


### PR DESCRIPTION
Bumps compatibility_date from 2025-12-11 to 2026-02-14 in both wrangler.jsonc and wrangler.test.jsonc.

Picks up any runtime behavior changes and compat flags enabled by default since December. Types and all 67 tests pass.