### PR TITLE
keep review-thread failures in thread

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -455,9 +455,16 @@ export class RepoAgent extends Agent<Env, RepoAgentState> {
       if (run?.waitingCommentId) {
         try {
           await updateComment(octokit, this.owner, this.repo, run.waitingCommentId, body);
-          this.storeFailureComment(key, run.waitingCommentId, "issue_comment");
-          log.info("failure_comment_updated_from_waiting", { conclusion, comment_id: run.waitingCommentId });
-          return;
+          const waitingKey = isReviewThread ? `i:${issueNumber}` : key;
+          this.storeFailureComment(waitingKey, run.waitingCommentId, "issue_comment");
+          log.info("failure_comment_updated_from_waiting", {
+            conclusion,
+            comment_id: run.waitingCommentId,
+            in_review_thread: !!isReviewThread,
+          });
+          if (!isReviewThread) {
+            return;
+          }
         } catch (error) {
           // Comment may have been deleted — fall through to create new
           log.errorWithException("failure_comment_waiting_edit_failed", error);


### PR DESCRIPTION
Fix Bonk failure replies for review-comment triggers that went through approval wait.

When Bonk was triggered from a PR review comment and the workflow entered a waiting-for-approval state, we posted a top-level waiting comment. On failure we edited that waiting comment and returned, so the review-thread reply never appeared.

- Continue past the waiting-comment edit when the trigger is a review thread so the in-thread failure reply is still created/updated.
- Store the waiting comment under the issue-level key while keeping the review-thread context intact.

Behavior summary table:
| Trigger context | Waiting comment updated | Failure reply location |
| --- | --- | --- |
| pull_request_review_comment (after approval wait) | yes (top-level) | review thread |

Tests:
- bun run tsc --noEmit
- bun run lint
- bun run test