### PR TITLE
Preserve Bonk comment prompt in action preflight

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -135,6 +135,9 @@ runs:
         PR_NUMBER: ${{ github.event.issue.pull_request.url && github.event.issue.number || github.event.pull_request.number || '' }}
         PR_URL: ${{ github.event.pull_request.url || github.event.issue.pull_request.url || '' }}
         USER_PROMPT: ${{ inputs.prompt }}
+        COMMENT_BODY: ${{ github.event.comment.body }}
+        REVIEW_BODY: ${{ github.event.review.body }}
+        MENTIONS: ${{ inputs.mentions }}
         ACTION_PATH: ${{ github.action_path }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         # fork-comment

--- a/github/script/context.ts
+++ b/github/script/context.ts
@@ -254,6 +254,29 @@ export function checkPermissionLevel(
   return null;
 }
 
+export function extractMentionPrompt(
+  body: string | undefined,
+  mentionsInput: string | undefined,
+): string | null {
+  const trimmed = body?.trim();
+  if (!trimmed) return null;
+
+  const mentions = (mentionsInput || "/bonk,@ask-bonk")
+    .split(",")
+    .map((mention) => mention.trim().toLowerCase())
+    .filter(Boolean);
+  if (mentions.length === 0) return null;
+
+  const lower = trimmed.toLowerCase();
+  if (mentions.some((mention) => lower === mention)) {
+    return "Summarize this thread";
+  }
+  if (mentions.some((mention) => lower.includes(mention))) {
+    return trimmed;
+  }
+  return null;
+}
+
 // Parses a TOKEN_PERMISSIONS input value (env var from action.yml).
 // Returns the parsed value (preset name string or JSON object) or undefined
 // for empty/whitespace/malformed input.

--- a/github/script/orchestrate.ts
+++ b/github/script/orchestrate.ts
@@ -18,6 +18,7 @@ import {
   parseTokenPermissions,
   validateOpenCodeVersion,
   checkPermissionLevel,
+  extractMentionPrompt,
   appendGitHubValue,
   core,
 } from "./context";
@@ -460,9 +461,17 @@ async function buildPrompt(): Promise<PromptResult> {
     core.info(`Non-fork PR context set: ${owner}/${repo}#${process.env.PR_NUMBER}`);
   }
 
-  const userPrompt = process.env.USER_PROMPT;
+  const userPrompt = process.env.USER_PROMPT?.trim();
   if (userPrompt) {
     parts.push(userPrompt);
+  } else if (parts.length > 0) {
+    const commentPrompt = extractMentionPrompt(
+      process.env.COMMENT_BODY || process.env.REVIEW_BODY,
+      process.env.MENTIONS,
+    );
+    if (commentPrompt) {
+      parts.push(commentPrompt);
+    }
   }
 
   return {

--- a/test/github-script.spec.ts
+++ b/test/github-script.spec.ts
@@ -1,5 +1,10 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
-import { detectForkFromPR, parseTokenPermissions, checkPermissionLevel } from "../github/script/context";
+import {
+  detectForkFromPR,
+  parseTokenPermissions,
+  checkPermissionLevel,
+  extractMentionPrompt,
+} from "../github/script/context";
 import { fetchWithRetry } from "../github/script/http";
 
 describe("GitHub Action script context", () => {
@@ -64,6 +69,22 @@ describe("OIDC exchange permission forwarding", () => {
 
   it("trims whitespace around preset names", () => {
     expect(parseTokenPermissions("  NO_PUSH  ")).toBe("NO_PUSH");
+  });
+});
+
+describe("GitHub Action mention prompt extraction", () => {
+  it("preserves the user's requested task from a Bonk mention", () => {
+    expect(extractMentionPrompt("/bonk fix the flaky test", "/bonk,@ask-bonk")).toBe(
+      "/bonk fix the flaky test",
+    );
+  });
+
+  it("returns the bare-mention fallback", () => {
+    expect(extractMentionPrompt("@ask-bonk", "/bonk,@ask-bonk")).toBe("Summarize this thread");
+  });
+
+  it("ignores comments without a configured mention", () => {
+    expect(extractMentionPrompt("please fix this", "/bonk,@ask-bonk")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Preserve the actual `/bonk` or `@ask-bonk` comment text when action preflight adds PR/fork guidance to `PROMPT`.
- Pass comment/review bodies and configured mentions into preflight so `opencode github run` receives both targeting guidance and the user's requested task.
- Add focused coverage for extracting mention prompts, including bare mentions and non-matching comments.

## Reviewer Notes
- Root cause: preflight set a non-empty `PROMPT` for PR context guidance, and OpenCode treats `PROMPT` as an override, so it never parsed the triggering comment. That made requests like “fix/refine this PR” look like generic PR-review runs.
- This keeps explicit workflow `prompt:` inputs highest priority. Comment extraction only runs when there is preflight guidance and no explicit `USER_PROMPT`.
- The helper intentionally mirrors OpenCode's mention behavior: exact bare mention maps to `Summarize this thread`; comments containing a configured mention preserve the full trimmed body.

## Testing
- `bun run test -- test/github-script.spec.ts`