### PR TITLE
fix: support pull_request_target in mention-check event handler

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -76,7 +76,7 @@ runs:
           pull_request_review)
             BODY="$REVIEW_BODY"
             ;;
-          issues|pull_request|workflow_dispatch|schedule)
+          issues|pull_request|pull_request_target|workflow_dispatch|schedule)
             echo "skip=false" >> $GITHUB_OUTPUT
             exit 0
             ;;


### PR DESCRIPTION
Fixes #175.

The `Check mentions` step's `case` statement didn't include `pull_request_target`, causing it to hit the `*)` catch-all and set `skip=true`. This made the action silently do nothing when triggered by `pull_request_target` events.

`pull_request_target` is the correct event for auto-triggering bonk on PR open when security matters — it runs the workflow from the base branch (production) rather than the PR's head branch, preventing PR authors from modifying the workflow to change bonk's behaviour.

**Change:** One line — add `pull_request_target` to the no-mention-needed event list alongside `pull_request`.