### PR TITLE
feat(github): resilient opencode run wrapper

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -192,15 +192,7 @@ runs:
         && (steps.preflight.outputs.is_fork != 'true' || steps.preflight.outputs.run_opencode == 'true')
       id: opencode
       shell: bash
-      run: |
-        set +e
-        # GH_TOKEN is the App token written to GITHUB_ENV by the OIDC exchange step.
-        export USE_GITHUB_TOKEN=true
-        export GITHUB_TOKEN="${GH_TOKEN}"
-        timeout 45m opencode github run
-        EXIT_CODE=$?
-        echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
-        exit $EXIT_CODE
+      run: bun run ${{ github.action_path }}/script/run-opencode.ts
       env:
         MODEL: ${{ inputs.model }}
         AGENT: ${{ inputs.agent }}
@@ -231,6 +223,11 @@ runs:
         GITHUB_SERVER_URL: ${{ github.server_url }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         OPENCODE_STATUS: ${{ steps.opencode.outcome }}
+        # Retry metadata from the resilient wrapper so the server can track
+        # success-after-retry, transient failures, and dirty-workspace refusals.
+        OPENCODE_EXIT_CODE: ${{ steps.opencode.outputs.exit_code }}
+        OPENCODE_ATTEMPT_COUNT: ${{ steps.opencode.outputs.attempt_count }}
+        OPENCODE_FINAL_REASON: ${{ steps.opencode.outputs.final_reason }}
         # Pass issue/PR context so the server can post failure comments even
         # when the run was never tracked or was already removed from activeRuns.
         ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}

--- a/github/script/context.ts
+++ b/github/script/context.ts
@@ -292,3 +292,16 @@ export function parseTokenPermissions(input: string | undefined): unknown {
   }
   return trimmed;
 }
+
+// Extracts a human-readable message from an unknown value.
+// Replaces the repetitive `error instanceof Error ? error.message : String(error)`
+// pattern that appears across every catch block in the action scripts.
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error);
+}

--- a/github/script/finalize.ts
+++ b/github/script/finalize.ts
@@ -16,6 +16,10 @@ async function main() {
   // failure rather than an intentional skip.
   const status = rawStatus === "skipped" ? "failure" : rawStatus;
 
+  const exitCode = process.env.OPENCODE_EXIT_CODE;
+  const attemptCount = process.env.OPENCODE_ATTEMPT_COUNT;
+  const finalReason = process.env.OPENCODE_FINAL_REASON;
+
   let oidcToken: string;
   try {
     oidcToken = await getOidcToken();
@@ -43,6 +47,10 @@ async function main() {
         // run was never tracked or was already removed from activeRuns.
         issue_number: context.issue?.number,
         run_url: context.runUrl,
+        // Retry metadata from the resilient wrapper.
+        ...(exitCode && { exit_code: Number(exitCode) }),
+        ...(attemptCount && { attempt_count: Number(attemptCount) }),
+        ...(finalReason && { final_reason: finalReason }),
       }),
     });
 

--- a/github/script/finalize.ts
+++ b/github/script/finalize.ts
@@ -1,8 +1,24 @@
 // Finalize tracking a workflow run
 // Called by the GitHub Action after OpenCode completes (with if: always())
 
-import { getContext, getOidcToken, getApiBaseUrl, core } from "./context";
+import { getContext, getOidcToken, getApiBaseUrl, core, getErrorMessage } from "./context";
 import { fetchWithRetry } from "./http";
+
+function parseOptionalNumberEnv(value: string | undefined): number | undefined {
+  if (value === undefined || value.trim() === "") {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptionalStringEnv(value: string | undefined): string | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  return value;
+}
 
 async function main() {
   const context = getContext();
@@ -16,16 +32,16 @@ async function main() {
   // failure rather than an intentional skip.
   const status = rawStatus === "skipped" ? "failure" : rawStatus;
 
-  const exitCode = process.env.OPENCODE_EXIT_CODE;
-  const attemptCount = process.env.OPENCODE_ATTEMPT_COUNT;
-  const finalReason = process.env.OPENCODE_FINAL_REASON;
+  const exitCode = parseOptionalNumberEnv(process.env.OPENCODE_EXIT_CODE);
+  const attemptCount = parseOptionalNumberEnv(process.env.OPENCODE_ATTEMPT_COUNT);
+  const finalReason = parseOptionalStringEnv(process.env.OPENCODE_FINAL_REASON);
 
   let oidcToken: string;
   try {
     oidcToken = await getOidcToken();
   } catch (error) {
     // Don't fail the workflow on finalize errors - just warn
-    core.warning(`Failed to get OIDC token for finalize: ${error}`);
+    core.warning(`Failed to get OIDC token for finalize: ${getErrorMessage(error)}`);
     return;
   }
 
@@ -48,9 +64,9 @@ async function main() {
         issue_number: context.issue?.number,
         run_url: context.runUrl,
         // Retry metadata from the resilient wrapper.
-        ...(exitCode && { exit_code: Number(exitCode) }),
-        ...(attemptCount && { attempt_count: Number(attemptCount) }),
-        ...(finalReason && { final_reason: finalReason }),
+        ...(exitCode !== undefined && { exit_code: exitCode }),
+        ...(attemptCount !== undefined && { attempt_count: attemptCount }),
+        ...(finalReason !== undefined && { final_reason: finalReason }),
       }),
     });
 
@@ -63,11 +79,11 @@ async function main() {
     core.info(`Successfully finalized run ${context.runId} with status ${statusInfo}`);
   } catch (error) {
     // Don't fail on finalize errors
-    core.warning(`Failed to finalize Bonk run tracking: ${error}`);
+    core.warning(`Failed to finalize Bonk run tracking: ${getErrorMessage(error)}`);
   }
 }
 
 main().catch((error) => {
   // Don't fail the workflow on finalize errors
-  core.warning(`Unexpected error in finalize: ${error}`);
+  core.warning(`Unexpected error in finalize: ${getErrorMessage(error)}`);
 });

--- a/github/script/orchestrate.ts
+++ b/github/script/orchestrate.ts
@@ -21,6 +21,7 @@ import {
   extractMentionPrompt,
   appendGitHubValue,
   core,
+  getErrorMessage,
 } from "./context";
 import { fetchWithRetry } from "./http";
 
@@ -124,8 +125,7 @@ async function checkCodeowners(
         return;
       }
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      core.warning(`Could not check team membership for @${teamPath}: ${message}`);
+      core.warning(`Could not check team membership for @${teamPath}: ${getErrorMessage(e)}`);
     }
   }
 
@@ -408,7 +408,7 @@ function buildForkGuidance(prNumber: string, owner: string, repo: string, headSh
   try {
     guidance = readFileSync(join(actionPath, "fork_guidance.md"), "utf-8");
   } catch (error) {
-    core.warning(`Could not read fork_guidance.md: ${error}`);
+    core.warning(`Could not read fork_guidance.md: ${getErrorMessage(error)}`);
     return `This PR is from a fork. You are in comment-only mode for PR #${prNumber} in ${owner}/${repo}. Do not attempt git write operations.`;
   }
 

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -42,23 +42,26 @@ export interface ClassifiedResult {
 
 // Narrow patterns anchored to known provider/network failure formats.
 // Avoid broad substrings that could match user code, test output, or log lines.
+// These patterns are anchored to actual error contexts (Error: prefix, system error
+// codes, or provider-specific frame text) so normal repo output does not trigger
+// a retry.
 const TRANSIENT_PATTERNS = [
   "Error: The operation was canceled",
-  "stream ended unexpectedly",
+  "stream ended unexpectedly (provider:",
   "Error: fetch failed",
   "Error: socket hang up",
-  "ECONNRESET",
-  "ETIMEDOUT",
-  "ECONNREFUSED",
-  "ENOTFOUND",
-  "EAI_AGAIN",
-  "ECONNABORTED",
-  "ERR_STREAM_ABORT",
-  "HTTP 429",
-  "HTTP 500",
-  "HTTP 502",
-  "HTTP 503",
-  "HTTP 504",
+  "Error: ECONNRESET",
+  "Error: ETIMEDOUT",
+  "Error: ECONNREFUSED",
+  "Error: ENOTFOUND",
+  "Error: EAI_AGAIN",
+  "Error: ECONNABORTED",
+  "Error [ERR_STREAM_ABORT]",
+  "Error: HTTP 429",
+  "Error: HTTP 500",
+  "Error: HTTP 502",
+  "Error: HTTP 503",
+  "Error: HTTP 504",
 ];
 
 function matchesTransientPattern(output: string): boolean {

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -40,28 +40,11 @@ export interface ClassifiedResult {
   reason: string;
 }
 
-// Narrow patterns anchored to known provider/network failure formats.
-// Avoid broad substrings that could match user code, test output, or log lines.
-// These patterns are anchored to actual error contexts (Error: prefix, system error
-// codes, or provider-specific frame text) so normal repo output does not trigger
-// a retry.
+// Retry only on provider-owned OpenCode frames. The output tail can include
+// arbitrary repo/test/tool output, so generic strings like "Error: fetch failed"
+// are intentionally not retry signals by themselves.
 const TRANSIENT_PATTERNS = [
-  "Error: The operation was canceled",
   "stream ended unexpectedly (provider:",
-  "Error: fetch failed",
-  "Error: socket hang up",
-  "Error: ECONNRESET",
-  "Error: ETIMEDOUT",
-  "Error: ECONNREFUSED",
-  "Error: ENOTFOUND",
-  "Error: EAI_AGAIN",
-  "Error: ECONNABORTED",
-  "Error [ERR_STREAM_ABORT]",
-  "Error: HTTP 429",
-  "Error: HTTP 500",
-  "Error: HTTP 502",
-  "Error: HTTP 503",
-  "Error: HTTP 504",
 ];
 
 function matchesTransientPattern(output: string): boolean {
@@ -170,7 +153,7 @@ interface SubprocessLike {
   stdout: ReadableStream;
   stderr: ReadableStream;
   exited: Promise<number>;
-  signalCode?: string | null;
+  readonly signalCode?: string | null;
 }
 
 export type SpawnFn = (
@@ -187,7 +170,9 @@ function defaultSpawnFn(
     stdout: proc.stdout,
     stderr: proc.stderr,
     exited: proc.exited,
-    signalCode: proc.signalCode,
+    get signalCode() {
+      return proc.signalCode;
+    },
   };
 }
 

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -105,13 +105,18 @@ export async function checkWorkspaceClean(): Promise<boolean> {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const output = await new Response(proc.stdout).text();
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      core.warning(`git status exited with ${exitCode}: ${output}`);
+      core.warning(
+        `git status exited with ${exitCode}: stdout=${stdout.trim()}, stderr=${stderr.trim()}`,
+      );
       return false;
     }
-    return output.trim().length === 0;
+    return stdout.trim().length === 0;
   } catch (error) {
     core.warning(`Could not check git status: ${getErrorMessage(error)}`);
     return false;
@@ -124,13 +129,18 @@ export async function getHeadSha(): Promise<string | null> {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const output = await new Response(proc.stdout).text();
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      core.warning(`git rev-parse HEAD exited with ${exitCode}: ${output}`);
+      core.warning(
+        `git rev-parse HEAD exited with ${exitCode}: stdout=${stdout.trim()}, stderr=${stderr.trim()}`,
+      );
       return null;
     }
-    return output.trim() || null;
+    return stdout.trim() || null;
   } catch (error) {
     core.warning(`Could not get HEAD SHA: ${getErrorMessage(error)}`);
     return null;
@@ -266,10 +276,10 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function configureOpenCodeEnv(): void {
+export function configureOpenCodeEnv(env: NodeJS.ProcessEnv = process.env): void {
   // Preserve the auth setup that the old inline shell block performed.
-  process.env.USE_GITHUB_TOKEN = "true";
-  process.env.GITHUB_TOKEN = process.env.GH_TOKEN ?? "";
+  env.USE_GITHUB_TOKEN = "true";
+  env.GITHUB_TOKEN = env.GH_TOKEN ?? "";
 }
 
 function setRunOutputs(exitCode: number, attempt: number, reason: string): void {

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -40,20 +40,32 @@ export interface ClassifiedResult {
   reason: string;
 }
 
-// Retry only on provider-owned OpenCode frames. The output tail can include
-// arbitrary repo/test/tool output, so generic strings like "Error: fetch failed"
-// are intentionally not retry signals by themselves.
+// Bounded mitigation for OpenCode provider-side stream drops / aborts.
 //
-// "Error: The operation was canceled." is retried only for unknown exit codes.
+// The wrapper has no machine-readable retry signal from OpenCode, so it looks at
+// the last lines of stderr/stdout. To avoid retrying arbitrary repo/test/tool
+// output, patterns are matched line-by-line and only for unknown exit codes.
 // Known signal/timeout codes (SIGINT 130, SIGKILL 137, SIGTERM 143, timeout 124)
 // take precedence, so real GitHub Actions cancellations are never retried.
-const TRANSIENT_PATTERNS = [
-  "stream ended unexpectedly (provider:",
-  "Error: The operation was canceled",
+//
+// TODO: replace this string parsing once OpenCode exposes a structured retry
+// signal (e.g. distinct exit code, JSON summary, or prefixed error line).
+const TRANSIENT_PATTERNS: Array<{ reason: string; re: RegExp }> = [
+  {
+    reason: "provider_stream_ended",
+    re: /^.*stream ended unexpectedly \(provider:.*$/m,
+  },
+  {
+    reason: "provider_operation_canceled",
+    re: /^(Error: )?The operation was canceled\.$/m,
+  },
 ];
 
-function matchesTransientPattern(output: string): boolean {
-  return TRANSIENT_PATTERNS.some((pattern) => output.includes(pattern));
+function matchTransientPattern(output: string): string | null {
+  for (const { reason, re } of TRANSIENT_PATTERNS) {
+    if (re.test(output)) return reason;
+  }
+  return null;
 }
 
 const EXIT_CODE_MAP: Record<number, ClassifiedResult> = {
@@ -77,11 +89,12 @@ export function classifyOpenCodeResult(result: RunResult): ClassifiedResult {
   }
 
   // For non-zero exits without a known code, look at the output tail
-  if (matchesTransientPattern(result.outputTail)) {
+  const matchedReason = matchTransientPattern(result.outputTail);
+  if (matchedReason) {
     return {
       classification: "transient",
       retryable: true,
-      reason: `transient failure (exit ${result.exitCode ?? "null"}, signal ${result.signal ?? "null"}, matched pattern)`,
+      reason: matchedReason,
     };
   }
 

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -18,7 +18,6 @@ import { core, getErrorMessage } from "./context";
 
 export interface RunResult {
   exitCode: number | null;
-  signal: string | null;
   outputTail: string;
   attempt: number;
 }
@@ -65,8 +64,7 @@ const TRANSIENT_PATTERNS = [
 ];
 
 function matchesTransientPattern(output: string): boolean {
-  const lower = output.toLowerCase();
-  return TRANSIENT_PATTERNS.some((pattern) => lower.includes(pattern.toLowerCase()));
+  return TRANSIENT_PATTERNS.some((pattern) => output.includes(pattern));
 }
 
 const EXIT_CODE_MAP: Record<number, ClassifiedResult> = {
@@ -97,7 +95,7 @@ export function classifyOpenCodeResult(result: RunResult): ClassifiedResult {
   return {
     classification: "unknown_failure",
     retryable: false,
-    reason: `unknown failure (exit ${result.exitCode ?? "null"}, signal ${result.signal ?? "null"})`,
+    reason: `unknown failure (exit ${result.exitCode ?? "null"})`,
   };
 }
 
@@ -159,7 +157,6 @@ export const OUTPUT_TAIL_LIMIT = 64 * 1024; // 64KB
 
 export interface SpawnResult {
   exitCode: number | null;
-  signal: string | null;
   outputTail: string;
 }
 
@@ -184,10 +181,6 @@ export async function runOpenCode(
   spawnFn: SpawnFn = defaultSpawnFn,
 ): Promise<SpawnResult> {
   try {
-    // Preserve the auth setup that the old inline shell block performed.
-    process.env.USE_GITHUB_TOKEN = "true";
-    process.env.GITHUB_TOKEN = process.env.GH_TOKEN ?? "";
-
     const proc = spawnFn(["timeout", "45m", "opencode", "github", "run"], {
       stdout: "pipe",
       stderr: "pipe",
@@ -252,13 +245,11 @@ export async function runOpenCode(
     const outputTail = Buffer.concat(chunks).toString("utf-8");
     return {
       exitCode: exitCode ?? null,
-      signal: null,
       outputTail,
     };
   } catch (error) {
     return {
       exitCode: 1,
-      signal: null,
       outputTail: getErrorMessage(error),
     };
   }
@@ -270,8 +261,16 @@ export async function runOpenCode(
 
 export const MAX_ATTEMPTS = 2;
 
+type SleepFn = (ms: number) => Promise<void>;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function configureOpenCodeEnv(): void {
+  // Preserve the auth setup that the old inline shell block performed.
+  process.env.USE_GITHUB_TOKEN = "true";
+  process.env.GITHUB_TOKEN = process.env.GH_TOKEN ?? "";
 }
 
 function setRunOutputs(exitCode: number, attempt: number, reason: string): void {
@@ -284,7 +283,10 @@ export async function main(
   runOpenCodeFn = runOpenCode,
   checkWorkspaceCleanFn = checkWorkspaceClean,
   getHeadShaFn = getHeadSha,
+  sleepFn: SleepFn = sleep,
 ): Promise<number> {
+  configureOpenCodeEnv();
+
   let beforeHead: string | null = null;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
@@ -302,7 +304,6 @@ export async function main(
 
       const result: RunResult = {
         exitCode: lastResult.exitCode,
-        signal: lastResult.signal,
         outputTail: lastResult.outputTail,
         attempt,
       };
@@ -347,7 +348,7 @@ export async function main(
         }
 
         core.warning(`Retryable failure detected: ${classified.reason}. Retrying in 2s...`);
-        await sleep(2000);
+        await sleepFn(2000);
         continue;
       }
 
@@ -371,6 +372,9 @@ if (import.meta.main) {
   main()
     .then((exitCode) => process.exit(exitCode))
     .catch((error) => {
-      core.setFailed(`run-opencode wrapper failed: ${error}`);
+      const message = getErrorMessage(error);
+      core.error(`run-opencode wrapper failed: ${message}`);
+      setRunOutputs(1, 0, `wrapper_crash: ${message}`);
+      process.exit(1);
     });
 }

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -18,6 +18,7 @@ import { core, getErrorMessage } from "./context";
 
 export interface RunResult {
   exitCode: number | null;
+  signal: string | null;
   outputTail: string;
   attempt: number;
 }
@@ -70,7 +71,11 @@ function matchesTransientPattern(output: string): boolean {
 const EXIT_CODE_MAP: Record<number, ClassifiedResult> = {
   0: { classification: "success", retryable: false, reason: "success" },
   124: { classification: "timeout", retryable: false, reason: "timeout (45m)" },
-  126: { classification: "command_not_executable", retryable: false, reason: "command not executable" },
+  126: {
+    classification: "command_not_executable",
+    retryable: false,
+    reason: "command not executable",
+  },
   127: { classification: "command_not_found", retryable: false, reason: "command not found" },
   130: { classification: "sigint", retryable: false, reason: "SIGINT" },
   137: { classification: "sigkill", retryable: false, reason: "SIGKILL / OOM" },
@@ -88,14 +93,14 @@ export function classifyOpenCodeResult(result: RunResult): ClassifiedResult {
     return {
       classification: "transient",
       retryable: true,
-      reason: `transient failure (exit ${result.exitCode ?? "null"}, matched pattern)`,
+      reason: `transient failure (exit ${result.exitCode ?? "null"}, signal ${result.signal ?? "null"}, matched pattern)`,
     };
   }
 
   return {
     classification: "unknown_failure",
     retryable: false,
-    reason: `unknown failure (exit ${result.exitCode ?? "null"})`,
+    reason: `unknown failure (exit ${result.exitCode ?? "null"}, signal ${result.signal ?? "null"})`,
   };
 }
 
@@ -157,6 +162,7 @@ export const OUTPUT_TAIL_LIMIT = 64 * 1024; // 64KB
 
 export interface SpawnResult {
   exitCode: number | null;
+  signal: string | null;
   outputTail: string;
 }
 
@@ -164,22 +170,28 @@ interface SubprocessLike {
   stdout: ReadableStream;
   stderr: ReadableStream;
   exited: Promise<number>;
+  signalCode?: string | null;
 }
 
-export type SpawnFn = (command: string[], options: { stdout: "pipe"; stderr: "pipe" }) => SubprocessLike;
+export type SpawnFn = (
+  command: string[],
+  options: { stdout: "pipe"; stderr: "pipe" },
+) => SubprocessLike;
 
-function defaultSpawnFn(command: string[], options: { stdout: "pipe"; stderr: "pipe" }): SubprocessLike {
+function defaultSpawnFn(
+  command: string[],
+  options: { stdout: "pipe"; stderr: "pipe" },
+): SubprocessLike {
   const proc = Bun.spawn(command, options);
   return {
     stdout: proc.stdout,
     stderr: proc.stderr,
     exited: proc.exited,
+    signalCode: proc.signalCode,
   };
 }
 
-export async function runOpenCode(
-  spawnFn: SpawnFn = defaultSpawnFn,
-): Promise<SpawnResult> {
+export async function runOpenCode(spawnFn: SpawnFn = defaultSpawnFn): Promise<SpawnResult> {
   try {
     const proc = spawnFn(["timeout", "45m", "opencode", "github", "run"], {
       stdout: "pipe",
@@ -245,11 +257,13 @@ export async function runOpenCode(
     const outputTail = Buffer.concat(chunks).toString("utf-8");
     return {
       exitCode: exitCode ?? null,
+      signal: proc.signalCode ?? null,
       outputTail,
     };
   } catch (error) {
     return {
       exitCode: 1,
+      signal: null,
       outputTail: getErrorMessage(error),
     };
   }
@@ -304,6 +318,7 @@ export async function main(
 
       const result: RunResult = {
         exitCode: lastResult.exitCode,
+        signal: lastResult.signal,
         outputTail: lastResult.outputTail,
         attempt,
       };

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -1,0 +1,373 @@
+// Resilient execution wrapper for `opencode github run` in GitHub Actions.
+//
+// Replaces the one-shot inline `timeout 45m opencode github run` shell block with
+// a typed boundary that retries once for likely transient failures while preserving
+// the existing finalisation contract.
+//
+// Known limitation: the retry guard only checks the git working tree (clean?)
+// and HEAD (unchanged?). It cannot detect GitHub-side effects made by the agent
+// such as comments, reviews, labels, or API calls. A fully robust solution would
+// require idempotency or request-level retry inside the provider layer, not at
+// the process wrapper level.
+
+import { core, getErrorMessage } from "./context";
+
+// ---------------------------------------------------------------------------
+// Classification
+// ---------------------------------------------------------------------------
+
+export interface RunResult {
+  exitCode: number | null;
+  signal: string | null;
+  outputTail: string;
+  attempt: number;
+}
+
+export type Classification =
+  | "success"
+  | "timeout"
+  | "command_not_found"
+  | "command_not_executable"
+  | "sigint"
+  | "sigkill"
+  | "sigterm"
+  | "transient"
+  | "unknown_failure";
+
+export interface ClassifiedResult {
+  classification: Classification;
+  retryable: boolean;
+  reason: string;
+}
+
+// Narrow patterns anchored to known provider/network failure formats.
+// Avoid broad substrings that could match user code, test output, or log lines.
+const TRANSIENT_PATTERNS = [
+  "Error: The operation was canceled",
+  "stream ended unexpectedly",
+  "Error: fetch failed",
+  "Error: socket hang up",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ERR_STREAM_ABORT",
+  "HTTP 429",
+  "HTTP 500",
+  "HTTP 502",
+  "HTTP 503",
+  "HTTP 504",
+];
+
+function matchesTransientPattern(output: string): boolean {
+  const lower = output.toLowerCase();
+  return TRANSIENT_PATTERNS.some((pattern) => lower.includes(pattern.toLowerCase()));
+}
+
+const EXIT_CODE_MAP: Record<number, ClassifiedResult> = {
+  0: { classification: "success", retryable: false, reason: "success" },
+  124: { classification: "timeout", retryable: false, reason: "timeout (45m)" },
+  126: { classification: "command_not_executable", retryable: false, reason: "command not executable" },
+  127: { classification: "command_not_found", retryable: false, reason: "command not found" },
+  130: { classification: "sigint", retryable: false, reason: "SIGINT" },
+  137: { classification: "sigkill", retryable: false, reason: "SIGKILL / OOM" },
+  143: { classification: "sigterm", retryable: false, reason: "SIGTERM" },
+};
+
+export function classifyOpenCodeResult(result: RunResult): ClassifiedResult {
+  // Exit code takes precedence — known codes map directly
+  if (result.exitCode !== null && result.exitCode in EXIT_CODE_MAP) {
+    return EXIT_CODE_MAP[result.exitCode];
+  }
+
+  // For non-zero exits without a known code, look at the output tail
+  if (matchesTransientPattern(result.outputTail)) {
+    return {
+      classification: "transient",
+      retryable: true,
+      reason: `transient failure (exit ${result.exitCode ?? "null"}, matched pattern)`,
+    };
+  }
+
+  return {
+    classification: "unknown_failure",
+    retryable: false,
+    reason: `unknown failure (exit ${result.exitCode ?? "null"}, signal ${result.signal ?? "null"})`,
+  };
+}
+
+export function shouldRetryOpenCodeResult(result: RunResult, maxAttempts: number): boolean {
+  if (result.attempt >= maxAttempts) {
+    return false;
+  }
+  const classified = classifyOpenCodeResult(result);
+  return classified.retryable;
+}
+
+// ---------------------------------------------------------------------------
+// Workspace mutation guard
+// ---------------------------------------------------------------------------
+
+export async function checkWorkspaceClean(): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["git", "status", "--porcelain"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      core.warning(`git status exited with ${exitCode}: ${output}`);
+      return false;
+    }
+    return output.trim().length === 0;
+  } catch (error) {
+    core.warning(`Could not check git status: ${getErrorMessage(error)}`);
+    return false;
+  }
+}
+
+export async function getHeadSha(): Promise<string | null> {
+  try {
+    const proc = Bun.spawn(["git", "rev-parse", "HEAD"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      core.warning(`git rev-parse HEAD exited with ${exitCode}: ${output}`);
+      return null;
+    }
+    return output.trim() || null;
+  } catch (error) {
+    core.warning(`Could not get HEAD SHA: ${getErrorMessage(error)}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Process execution
+// ---------------------------------------------------------------------------
+
+export const OUTPUT_TAIL_LIMIT = 64 * 1024; // 64KB
+
+export interface SpawnResult {
+  exitCode: number | null;
+  signal: string | null;
+  outputTail: string;
+}
+
+interface SubprocessLike {
+  stdout: ReadableStream;
+  stderr: ReadableStream;
+  exited: Promise<number>;
+}
+
+export type SpawnFn = (command: string[], options: { stdout: "pipe"; stderr: "pipe" }) => SubprocessLike;
+
+function defaultSpawnFn(command: string[], options: { stdout: "pipe"; stderr: "pipe" }): SubprocessLike {
+  const proc = Bun.spawn(command, options);
+  return {
+    stdout: proc.stdout,
+    stderr: proc.stderr,
+    exited: proc.exited,
+  };
+}
+
+export async function runOpenCode(
+  spawnFn: SpawnFn = defaultSpawnFn,
+): Promise<SpawnResult> {
+  try {
+    // Preserve the auth setup that the old inline shell block performed.
+    process.env.USE_GITHUB_TOKEN = "true";
+    process.env.GITHUB_TOKEN = process.env.GH_TOKEN ?? "";
+
+    const proc = spawnFn(["timeout", "45m", "opencode", "github", "run"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    function pushChunk(data: Uint8Array) {
+      const buf = Buffer.from(data);
+      if (buf.length > OUTPUT_TAIL_LIMIT) {
+        // A single chunk exceeds the limit — keep only its tail and discard
+        // everything that came before.
+        chunks.length = 0;
+        chunks.push(buf.subarray(-OUTPUT_TAIL_LIMIT));
+        totalBytes = OUTPUT_TAIL_LIMIT;
+        return;
+      }
+
+      chunks.push(buf);
+      totalBytes += buf.length;
+
+      // Trim oldest bytes until we're under the limit, slicing the first chunk
+      // if necessary instead of discarding it entirely. This preserves more of
+      // the tail than the old whole-chunk removal strategy.
+      while (totalBytes > OUTPUT_TAIL_LIMIT) {
+        const excess = totalBytes - OUTPUT_TAIL_LIMIT;
+        const first = chunks[0];
+        if (first.length <= excess) {
+          chunks.shift();
+          totalBytes -= first.length;
+        } else {
+          chunks[0] = first.subarray(excess);
+          totalBytes -= excess;
+        }
+      }
+    }
+
+    const stdoutDone = proc.stdout.pipeTo(
+      new WritableStream({
+        write(chunk: Uint8Array) {
+          pushChunk(chunk);
+          process.stdout.write(chunk);
+        },
+      }),
+    );
+
+    const stderrDone = proc.stderr.pipeTo(
+      new WritableStream({
+        write(chunk: Uint8Array) {
+          pushChunk(chunk);
+          process.stderr.write(chunk);
+        },
+      }),
+    );
+
+    const exitCode = await proc.exited;
+    // Wait for stdout/stderr to fully drain before classifying the output.
+    // Otherwise the final error line might be missed in a stream-flush race.
+    await Promise.allSettled([stdoutDone, stderrDone]);
+
+    const outputTail = Buffer.concat(chunks).toString("utf-8");
+    return {
+      exitCode: exitCode ?? null,
+      signal: null,
+      outputTail,
+    };
+  } catch (error) {
+    return {
+      exitCode: 1,
+      signal: null,
+      outputTail: getErrorMessage(error),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export const MAX_ATTEMPTS = 2;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function setRunOutputs(exitCode: number, attempt: number, reason: string): void {
+  core.setOutput("exit_code", String(exitCode));
+  core.setOutput("attempt_count", String(attempt));
+  core.setOutput("final_reason", reason);
+}
+
+export async function main(
+  runOpenCodeFn = runOpenCode,
+  checkWorkspaceCleanFn = checkWorkspaceClean,
+  getHeadShaFn = getHeadSha,
+): Promise<number> {
+  let beforeHead: string | null = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    core.info(`Starting opencode github run (attempt ${attempt}/${MAX_ATTEMPTS})`);
+
+    if (attempt === 1) {
+      beforeHead = await getHeadShaFn();
+    }
+
+    let lastResult: SpawnResult;
+    try {
+      const startTime = Date.now();
+      lastResult = await runOpenCodeFn();
+      const durationMs = Date.now() - startTime;
+
+      const result: RunResult = {
+        exitCode: lastResult.exitCode,
+        signal: lastResult.signal,
+        outputTail: lastResult.outputTail,
+        attempt,
+      };
+
+      const classified = classifyOpenCodeResult(result);
+
+      core.info(
+        `opencode attempt ${attempt} finished in ${durationMs}ms with exit_code=${lastResult.exitCode ?? "null"}, classification=${classified.classification}, reason=${classified.reason}`,
+      );
+
+      if (classified.classification === "success") {
+        setRunOutputs(lastResult.exitCode ?? 0, attempt, classified.reason);
+        core.info("opencode completed successfully");
+        return 0;
+      }
+
+      if (shouldRetryOpenCodeResult(result, MAX_ATTEMPTS)) {
+        const isClean = await checkWorkspaceCleanFn();
+        if (!isClean) {
+          core.error(
+            `Retryable failure detected, but workspace is not clean. Refusing to retry to avoid double-applying effects.`,
+          );
+          setRunOutputs(lastResult.exitCode ?? 1, attempt, "transient_but_workspace_dirty");
+          return lastResult.exitCode ?? 1;
+        }
+
+        const afterHead = await getHeadShaFn();
+        if (beforeHead === null || afterHead === null) {
+          core.error(
+            `Retryable failure detected, but HEAD state could not be determined (before=${beforeHead ?? "null"}, after=${afterHead ?? "null"}). Refusing to retry to avoid double-applying effects.`,
+          );
+          setRunOutputs(lastResult.exitCode ?? 1, attempt, "transient_but_head_unknown");
+          return lastResult.exitCode ?? 1;
+        }
+
+        if (beforeHead !== afterHead) {
+          core.error(
+            `Retryable failure detected, but HEAD moved (${beforeHead.slice(0, 7)} → ${afterHead.slice(0, 7)}). Refusing to retry to avoid double-applying effects.`,
+          );
+          setRunOutputs(lastResult.exitCode ?? 1, attempt, "transient_but_head_moved");
+          return lastResult.exitCode ?? 1;
+        }
+
+        core.warning(`Retryable failure detected: ${classified.reason}. Retrying in 2s...`);
+        await sleep(2000);
+        continue;
+      }
+
+      // Non-retryable failure
+      core.error(`opencode failed with non-retryable classification: ${classified.reason}`);
+      setRunOutputs(lastResult.exitCode ?? 1, attempt, classified.reason);
+      return lastResult.exitCode ?? 1;
+    } catch (error) {
+      const message = getErrorMessage(error);
+      core.error(`Unexpected error during opencode run: ${message}`);
+      setRunOutputs(1, attempt, `unexpected_error: ${message}`);
+      return 1;
+    }
+  }
+
+  // Safety net — should never reach here because the loop always returns
+  return 1;
+}
+
+if (import.meta.main) {
+  main()
+    .then((exitCode) => process.exit(exitCode))
+    .catch((error) => {
+      core.setFailed(`run-opencode wrapper failed: ${error}`);
+    });
+}

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -43,8 +43,13 @@ export interface ClassifiedResult {
 // Retry only on provider-owned OpenCode frames. The output tail can include
 // arbitrary repo/test/tool output, so generic strings like "Error: fetch failed"
 // are intentionally not retry signals by themselves.
+//
+// "Error: The operation was canceled." is retried only for unknown exit codes.
+// Known signal/timeout codes (SIGINT 130, SIGKILL 137, SIGTERM 143, timeout 124)
+// take precedence, so real GitHub Actions cancellations are never retried.
 const TRANSIENT_PATTERNS = [
   "stream ended unexpectedly (provider:",
+  "Error: The operation was canceled",
 ];
 
 function matchesTransientPattern(output: string): boolean {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -239,12 +239,19 @@ export class RepoAgent extends Agent<Env, RepoAgentState> {
     fallbackIssueNumber?: number,
     fallbackRunUrl?: string,
     actor?: string,
+    retryMeta?: { exit_code?: number; attempt_count?: number; final_reason?: string },
   ): Promise<void> {
     const run = this.state.activeRuns[runId];
     const issueNumber = run?.issueNumber ?? fallbackIssueNumber;
     const log = this.logger(runId, issueNumber);
 
-    log.info("run_finalizing", { status, has_active_run: !!run });
+    log.info("run_finalizing", {
+      status,
+      has_active_run: !!run,
+      ...(retryMeta?.exit_code !== undefined && { exit_code: retryMeta.exit_code }),
+      ...(retryMeta?.attempt_count !== undefined && { attempt_count: retryMeta.attempt_count }),
+      ...(retryMeta?.final_reason && { final_reason: retryMeta.final_reason }),
+    });
 
     // Run was never tracked or was already removed (e.g., polling timeout
     // removed it before the action's finalize step arrived). For non-success

--- a/src/index.ts
+++ b/src/index.ts
@@ -608,7 +608,18 @@ apiGithub.put("/track", async (c) => {
       `${body.owner}/${body.repo}`,
     );
     await agent.setInstallationId(installationId, installationSource);
-    await agent.finalizeRun(body.run_id, body.status, body.issue_number, body.run_url, actor);
+    await agent.finalizeRun(
+      body.run_id,
+      body.status,
+      body.issue_number,
+      body.run_url,
+      actor,
+      {
+        exit_code: body.exit_code,
+        attempt_count: body.attempt_count,
+        final_reason: body.final_reason,
+      },
+    );
 
     finalizeLog.info("finalize_completed", {
       installation_id: installationId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -608,17 +608,24 @@ apiGithub.put("/track", async (c) => {
       `${body.owner}/${body.repo}`,
     );
     await agent.setInstallationId(installationId, installationSource);
+    const retryMeta =
+      body.exit_code !== undefined ||
+      body.attempt_count !== undefined ||
+      body.final_reason !== undefined
+        ? {
+            exit_code: body.exit_code,
+            attempt_count: body.attempt_count,
+            final_reason: body.final_reason,
+          }
+        : undefined;
+
     await agent.finalizeRun(
       body.run_id,
       body.status,
       body.issue_number,
       body.run_url,
       actor,
-      {
-        exit_code: body.exit_code,
-        attempt_count: body.attempt_count,
-        final_reason: body.final_reason,
-      },
+      retryMeta,
     );
 
     finalizeLog.info("finalize_completed", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ ask.use("*", async (c, next) => {
   if (!secret) {
     return c.json({ error: "Ask endpoint is disabled" }, 403);
   }
-  const auth = bearerAuth<{ Bindings: Env }>({ token: secret });
+  const auth = bearerAuth({ token: secret });
   return auth(c, next);
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,11 @@ export interface FinalizeWorkflowRequest {
   // removed it before the action's finalize step ran).
   issue_number?: number;
   run_url?: string;
+  // Retry metadata from the resilient wrapper so the server can track
+  // success-after-retry, transient failures, and dirty-workspace refusals.
+  exit_code?: number;
+  attempt_count?: number;
+  final_reason?: string;
 }
 
 // Request to check/create workflow file (POST /api/github/setup)

--- a/test/context.spec.ts
+++ b/test/context.spec.ts
@@ -5,7 +5,6 @@ import {
   checkPermissionLevel,
   extractMentionPrompt,
 } from "../github/script/context";
-import { fetchWithRetry } from "../github/script/http";
 
 describe("GitHub Action script context", () => {
   beforeEach(() => {
@@ -137,45 +136,4 @@ describe("Permission level checking", () => {
       expect(error).toContain(required);
     },
   );
-});
-
-describe("GitHub Action script HTTP retry", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("retries on transient failures", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response("server error", { status: 503 }))
-      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
-
-    const response = await fetchWithRetry(
-      "https://example.com",
-      { method: "GET" },
-      { retries: 1, baseDelayMs: 1, timeoutMs: 1000 },
-    );
-
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not retry non-transient status codes", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response("bad request", { status: 400 }));
-
-    const response = await fetchWithRetry(
-      "https://example.com",
-      { method: "GET" },
-      { retries: 2, baseDelayMs: 1, timeoutMs: 1000 },
-    );
-
-    expect(response.status).toBe(400);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
 });

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -1,0 +1,43 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithRetry } from "../github/script/http";
+
+describe("GitHub Action script HTTP retry", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries on transient failures", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("server error", { status: 503 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const response = await fetchWithRetry(
+      "https://example.com",
+      { method: "GET" },
+      { retries: 1, baseDelayMs: 1, timeoutMs: 1000 },
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-transient status codes", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("bad request", { status: 400 }));
+
+    const response = await fetchWithRetry(
+      "https://example.com",
+      { method: "GET" },
+      { retries: 2, baseDelayMs: 1, timeoutMs: 1000 },
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -7,7 +7,6 @@ import {
   main,
   OUTPUT_TAIL_LIMIT,
   type SpawnFn,
-  type SpawnResult,
 } from "../github/script/run-opencode";
 import type { RunResult } from "../github/script/run-opencode";
 
@@ -18,12 +17,13 @@ import type { RunResult } from "../github/script/run-opencode";
 function makeResult(overrides: Partial<RunResult> = {}): RunResult {
   return {
     exitCode: 0,
-    signal: null,
     outputTail: "",
     attempt: 1,
     ...overrides,
   };
 }
+
+const noSleep = async (_ms: number) => {};
 
 // Test double for SpawnFn that returns real ReadableStream objects.
 // Exercises the actual stream wiring in runOpenCode without requiring
@@ -88,6 +88,7 @@ describe("classifyOpenCodeResult", () => {
   it.each([
     { outputTail: "Test output: 500 Internal Server Error", label: "HTTP 500 in test output" },
     { outputTail: "Expected fetch failed", label: "fetch failed without Error: prefix" },
+    { outputTail: "error: fetch failed in mock test", label: "lowercase error prefix" },
     { outputTail: "The operation was canceled", label: "The operation was canceled without Error: prefix" },
     { outputTail: "Simulated ECONNRESET in test", label: "ECONNRESET in test output" },
     { outputTail: "Simulated ETIMEDOUT in test", label: "ETIMEDOUT in test output" },
@@ -179,7 +180,6 @@ describe("main", () => {
   it("succeeds on first attempt", async () => {
     const run = async () => ({
       exitCode: 0,
-      signal: null,
       outputTail: "success",
     });
     const clean = () => Promise.resolve(true);
@@ -207,7 +207,7 @@ describe("main", () => {
     const clean = () => Promise.resolve(true);
     const headSha = () => Promise.resolve("abc1234");
 
-    const exitCode = await main(run, clean, headSha);
+    const exitCode = await main(run, clean, headSha, noSleep);
     expect(exitCode).toBe(0);
     expect(callCount).toBe(2);
 
@@ -265,7 +265,6 @@ describe("main", () => {
   it("does not retry non-retryable failure", async () => {
     const run = async () => ({
       exitCode: 127,
-      signal: null,
       outputTail: "",
     });
     const clean = () => Promise.resolve(true);

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -72,32 +72,51 @@ describe("classifyOpenCodeResult", () => {
   it.each([
     { exitCode: 1, outputTail: "some error", classification: "unknown_failure", retryable: false, label: "unknown failure" },
     { exitCode: 1, outputTail: "Error: The operation was canceled", classification: "transient", retryable: true, label: "transient pattern" },
-    { exitCode: 1, outputTail: "stream ended unexpectedly", classification: "transient", retryable: true, label: "stream ended" },
+    { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", classification: "transient", retryable: true, label: "stream ended" },
     { exitCode: 1, outputTail: "Error: fetch failed: 502", classification: "transient", retryable: true, label: "fetch failure" },
-    { exitCode: 1, outputTail: "HTTP 429", classification: "transient", retryable: true, label: "rate limit" },
-    { exitCode: 1, outputTail: "HTTP 503", classification: "transient", retryable: true, label: "503" },
-    { exitCode: 1, outputTail: "ECONNRESET", classification: "transient", retryable: true, label: "network error" },
+    { exitCode: 1, outputTail: "Error: HTTP 429", classification: "transient", retryable: true, label: "rate limit" },
+    { exitCode: 1, outputTail: "Error: HTTP 503", classification: "transient", retryable: true, label: "503" },
+    { exitCode: 1, outputTail: "Error: ECONNRESET", classification: "transient", retryable: true, label: "network error" },
+    { exitCode: 1, outputTail: "Error [ERR_STREAM_ABORT]: aborted", classification: "transient", retryable: true, label: "ERR_STREAM_ABORT" },
   ])("exit %d with %s → %s", ({ exitCode, outputTail, classification, retryable }) => {
     const result = classifyOpenCodeResult(makeResult({ exitCode, outputTail }));
     expect(result.classification).toBe(classification);
     expect(result.retryable).toBe(retryable);
   });
 
+  // Negative tests: every pattern must NOT match ordinary repo/test/tool output.
   it.each([
-    { outputTail: "Test output: 500 Internal Server Error", label: "normal test output" },
-    { outputTail: "Expected fetch failed", label: "plain fetch failed without Error: prefix" },
+    { outputTail: "Test output: 500 Internal Server Error", label: "HTTP 500 in test output" },
+    { outputTail: "Expected fetch failed", label: "fetch failed without Error: prefix" },
     { outputTail: "The operation was canceled", label: "The operation was canceled without Error: prefix" },
+    { outputTail: "Simulated ECONNRESET in test", label: "ECONNRESET in test output" },
+    { outputTail: "Simulated ETIMEDOUT in test", label: "ETIMEDOUT in test output" },
+    { outputTail: "Simulated ECONNREFUSED in test", label: "ECONNREFUSED in test output" },
+    { outputTail: "Simulated ENOTFOUND in test", label: "ENOTFOUND in test output" },
+    { outputTail: "Simulated EAI_AGAIN in test", label: "EAI_AGAIN in test output" },
+    { outputTail: "Simulated ECONNABORTED in test", label: "ECONNABORTED in test output" },
+    { outputTail: "Simulated ERR_STREAM_ABORT in test", label: "ERR_STREAM_ABORT in test output" },
+    { outputTail: "Simulated HTTP 429 in test", label: "HTTP 429 in test output" },
+    { outputTail: "Simulated HTTP 502 in test", label: "HTTP 502 in test output" },
+    { outputTail: "Simulated HTTP 504 in test", label: "HTTP 504 in test output" },
+    { outputTail: "stream ended unexpectedly", label: "stream ended unexpectedly without provider frame" },
   ])("does not classify as transient when output contains $label", ({ outputTail }) => {
     const result = classifyOpenCodeResult(makeResult({ exitCode: 1, outputTail }));
     expect(result.classification).toBe("unknown_failure");
     expect(result.retryable).toBe(false);
   });
+
+  it("classifies as transient only when exit code is non-zero", () => {
+    const match = classifyOpenCodeResult(makeResult({ exitCode: 0, outputTail: "stream ended unexpectedly (provider: openai)" }));
+    expect(match.classification).toBe("success");
+    expect(match.retryable).toBe(false);
+  });
 });
 
 describe("shouldRetryOpenCodeResult", () => {
   it.each([
-    { exitCode: 1, outputTail: "stream ended unexpectedly", attempt: 1, maxAttempts: 2, expected: true, label: "transient within limit" },
-    { exitCode: 1, outputTail: "stream ended unexpectedly", attempt: 2, maxAttempts: 2, expected: false, label: "at limit" },
+    { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", attempt: 1, maxAttempts: 2, expected: true, label: "transient within limit" },
+    { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", attempt: 2, maxAttempts: 2, expected: false, label: "at limit" },
     { exitCode: 124, outputTail: "", attempt: 1, maxAttempts: 2, expected: false, label: "non-retryable classification" },
     { exitCode: 1, outputTail: "some error", attempt: 1, maxAttempts: 2, expected: false, label: "unknown failure" },
   ])("$label", ({ exitCode, outputTail, attempt, maxAttempts, expected }) => {

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -115,13 +115,15 @@ describe("classifyOpenCodeResult", () => {
   });
 
   it.each([
-    { exitCode: 1, outputTail: "some error", classification: "unknown_failure", retryable: false, label: "unknown failure" },
-    { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", classification: "transient", retryable: true, label: "stream ended" },
-    { exitCode: 1, outputTail: "Error: The operation was canceled.", classification: "transient", retryable: true, label: "provider cancellation" },
-  ])("exit %d with %s → %s", ({ exitCode, outputTail, classification, retryable }) => {
+    { exitCode: 1, outputTail: "some error", classification: "unknown_failure", retryable: false, reason: "unknown failure (exit 1, signal null)", label: "unknown failure" },
+    { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", classification: "transient", retryable: true, reason: "provider_stream_ended", label: "stream ended" },
+    { exitCode: 1, outputTail: "The operation was canceled.", classification: "transient", retryable: true, reason: "provider_operation_canceled", label: "provider cancellation" },
+    { exitCode: 1, outputTail: "Error: The operation was canceled.", classification: "transient", retryable: true, reason: "provider_operation_canceled", label: "provider cancellation with Error: prefix" },
+  ])("exit $exitCode with $label → $classification", ({ exitCode, outputTail, classification, retryable, reason }) => {
     const result = classifyOpenCodeResult(makeResult({ exitCode, outputTail }));
     expect(result.classification).toBe(classification);
     expect(result.retryable).toBe(retryable);
+    expect(result.reason).toBe(reason);
   });
 
   // Negative tests: every pattern must NOT match ordinary repo/test/tool output.
@@ -133,7 +135,9 @@ describe("classifyOpenCodeResult", () => {
     { outputTail: "Error: ECONNRESET", label: "exact generic ECONNRESET" },
     { outputTail: "Expected fetch failed", label: "fetch failed without Error: prefix" },
     { outputTail: "error: fetch failed in mock test", label: "lowercase error prefix" },
-    { outputTail: "The operation was canceled", label: "The operation was canceled without Error: prefix" },
+    { outputTail: "The operation was canceled", label: "The operation was canceled without trailing period" },
+    { outputTail: "Test expected \"The operation was canceled.\" somewhere in output", label: "The operation was canceled. embedded in prose" },
+    { outputTail: "##[error]The operation was canceled.", label: "GitHub Actions cancellation annotation" },
     { outputTail: "Simulated ECONNRESET in test", label: "ECONNRESET in test output" },
     { outputTail: "Simulated ETIMEDOUT in test", label: "ETIMEDOUT in test output" },
     { outputTail: "Simulated ECONNREFUSED in test", label: "ECONNREFUSED in test output" },
@@ -293,6 +297,24 @@ describe("main", () => {
     expect(core.setOutput).toHaveBeenCalledWith("exit_code", "0");
     expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "2");
     expect(core.setOutput).toHaveBeenCalledWith("final_reason", "success");
+  });
+
+  it("retries provider_operation_canceled once then stops", async () => {
+    let callCount = 0;
+    const run = async () => {
+      callCount++;
+      return runOpenCode(spawnTestDouble("The operation was canceled.", "", 1));
+    };
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve("abc1234");
+
+    const exitCode = await main(run, clean, headSha, noSleep);
+    expect(exitCode).toBe(1);
+    expect(callCount).toBe(2);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "2");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "provider_operation_canceled");
   });
 
   it("does not retry when workspace is dirty", async () => {

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -117,6 +117,7 @@ describe("classifyOpenCodeResult", () => {
   it.each([
     { exitCode: 1, outputTail: "some error", classification: "unknown_failure", retryable: false, label: "unknown failure" },
     { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", classification: "transient", retryable: true, label: "stream ended" },
+    { exitCode: 1, outputTail: "Error: The operation was canceled.", classification: "transient", retryable: true, label: "provider cancellation" },
   ])("exit %d with %s → %s", ({ exitCode, outputTail, classification, retryable }) => {
     const result = classifyOpenCodeResult(makeResult({ exitCode, outputTail }));
     expect(result.classification).toBe(classification);
@@ -130,7 +131,6 @@ describe("classifyOpenCodeResult", () => {
     { outputTail: "Error: HTTP 500", label: "exact generic HTTP 500" },
     { outputTail: "Error: HTTP 503", label: "exact generic HTTP 503" },
     { outputTail: "Error: ECONNRESET", label: "exact generic ECONNRESET" },
-    { outputTail: "Error: The operation was canceled", label: "generic cancellation" },
     { outputTail: "Expected fetch failed", label: "fetch failed without Error: prefix" },
     { outputTail: "error: fetch failed in mock test", label: "lowercase error prefix" },
     { outputTail: "The operation was canceled", label: "The operation was canceled without Error: prefix" },
@@ -155,6 +155,14 @@ describe("classifyOpenCodeResult", () => {
     const match = classifyOpenCodeResult(makeResult({ exitCode: 0, outputTail: "stream ended unexpectedly (provider: openai)" }));
     expect(match.classification).toBe("success");
     expect(match.retryable).toBe(false);
+  });
+
+  it("does not retry real GitHub Actions cancellation even if output mentions operation canceled", () => {
+    const result = classifyOpenCodeResult(
+      makeResult({ exitCode: 143, outputTail: "Error: The operation was canceled." }),
+    );
+    expect(result.classification).toBe("sigterm");
+    expect(result.retryable).toBe(false);
   });
 });
 

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -17,6 +17,7 @@ import type { RunResult } from "../github/script/run-opencode";
 function makeResult(overrides: Partial<RunResult> = {}): RunResult {
   return {
     exitCode: 0,
+    signal: null,
     outputTail: "",
     attempt: 1,
     ...overrides,
@@ -47,6 +48,24 @@ function spawnTestDouble(
       },
     }),
     exited: Promise.resolve(exitCode),
+    signalCode: null,
+  });
+}
+
+function spawnSignalTestDouble(signalCode: string): SpawnFn {
+  return () => ({
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    exited: Promise.resolve(137),
+    signalCode,
   });
 }
 
@@ -136,6 +155,12 @@ describe("runOpenCode", () => {
     expect(result.exitCode).toBe(0);
     expect(result.outputTail).toContain("hello stdout");
     expect(result.outputTail).toContain("hello stderr");
+  });
+
+  it("captures signal termination metadata", async () => {
+    const result = await runOpenCode(spawnSignalTestDouble("SIGKILL"));
+    expect(result.exitCode).toBe(137);
+    expect(result.signal).toBe("SIGKILL");
   });
 
   it("slices oversized output to preserve the tail", async () => {
@@ -265,6 +290,7 @@ describe("main", () => {
   it("does not retry non-retryable failure", async () => {
     const run = async () => ({
       exitCode: 127,
+      signal: null,
       outputTail: "",
     });
     const clean = () => Promise.resolve(true);

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { core } from "../github/script/context";
 import {
   classifyOpenCodeResult,
+  configureOpenCodeEnv,
   shouldRetryOpenCodeResult,
   runOpenCode,
   main,
@@ -247,6 +248,20 @@ describe("main", () => {
     expect(core.setOutput).toHaveBeenCalledWith("exit_code", "0");
     expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
     expect(core.setOutput).toHaveBeenCalledWith("final_reason", "success");
+  });
+
+  it("configures auth env from GH_TOKEN", () => {
+    const env: NodeJS.ProcessEnv = { GH_TOKEN: "app-installation-token" };
+    configureOpenCodeEnv(env);
+    expect(env.USE_GITHUB_TOKEN).toBe("true");
+    expect(env.GITHUB_TOKEN).toBe("app-installation-token");
+  });
+
+  it("falls back to empty GITHUB_TOKEN when GH_TOKEN is missing", () => {
+    const env: NodeJS.ProcessEnv = {};
+    configureOpenCodeEnv(env);
+    expect(env.USE_GITHUB_TOKEN).toBe("true");
+    expect(env.GITHUB_TOKEN).toBe("");
   });
 
   it("retries transient failure then succeeds", async () => {

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { core } from "../github/script/context";
+import {
+  classifyOpenCodeResult,
+  shouldRetryOpenCodeResult,
+  runOpenCode,
+  main,
+  OUTPUT_TAIL_LIMIT,
+  type SpawnFn,
+  type SpawnResult,
+} from "../github/script/run-opencode";
+import type { RunResult } from "../github/script/run-opencode";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    exitCode: 0,
+    signal: null,
+    outputTail: "",
+    attempt: 1,
+    ...overrides,
+  };
+}
+
+// Test double for SpawnFn that returns real ReadableStream objects.
+// Exercises the actual stream wiring in runOpenCode without requiring
+// Bun.spawn (which is unavailable in the Workers test environment).
+function spawnTestDouble(
+  stdoutData: string,
+  stderrData: string,
+  exitCode: number,
+): SpawnFn {
+  return () => ({
+    stdout: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stdoutData));
+        controller.close();
+      },
+    }),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(stderrData));
+        controller.close();
+      },
+    }),
+    exited: Promise.resolve(exitCode),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// OpenCode Run Classification
+// ---------------------------------------------------------------------------
+
+describe("classifyOpenCodeResult", () => {
+  it.each([
+    { exitCode: 0, classification: "success", retryable: false, label: "success" },
+    { exitCode: 124, classification: "timeout", retryable: false, label: "timeout" },
+    { exitCode: 126, classification: "command_not_executable", retryable: false, label: "not executable" },
+    { exitCode: 127, classification: "command_not_found", retryable: false, label: "not found" },
+    { exitCode: 130, classification: "sigint", retryable: false, label: "SIGINT" },
+    { exitCode: 137, classification: "sigkill", retryable: false, label: "SIGKILL" },
+    { exitCode: 143, classification: "sigterm", retryable: false, label: "SIGTERM" },
+  ])("exit %d → %s", ({ exitCode, classification, retryable }) => {
+    const result = classifyOpenCodeResult(makeResult({ exitCode }));
+    expect(result.classification).toBe(classification);
+    expect(result.retryable).toBe(retryable);
+  });
+
+  it.each([
+    { exitCode: 1, outputTail: "some error", classification: "unknown_failure", retryable: false, label: "unknown failure" },
+    { exitCode: 1, outputTail: "Error: The operation was canceled", classification: "transient", retryable: true, label: "transient pattern" },
+    { exitCode: 1, outputTail: "stream ended unexpectedly", classification: "transient", retryable: true, label: "stream ended" },
+    { exitCode: 1, outputTail: "Error: fetch failed: 502", classification: "transient", retryable: true, label: "fetch failure" },
+    { exitCode: 1, outputTail: "HTTP 429", classification: "transient", retryable: true, label: "rate limit" },
+    { exitCode: 1, outputTail: "HTTP 503", classification: "transient", retryable: true, label: "503" },
+    { exitCode: 1, outputTail: "ECONNRESET", classification: "transient", retryable: true, label: "network error" },
+  ])("exit %d with %s → %s", ({ exitCode, outputTail, classification, retryable }) => {
+    const result = classifyOpenCodeResult(makeResult({ exitCode, outputTail }));
+    expect(result.classification).toBe(classification);
+    expect(result.retryable).toBe(retryable);
+  });
+
+  it.each([
+    { outputTail: "Test output: 500 Internal Server Error", label: "normal test output" },
+    { outputTail: "Expected fetch failed", label: "plain fetch failed without Error: prefix" },
+    { outputTail: "The operation was canceled", label: "The operation was canceled without Error: prefix" },
+  ])("does not classify as transient when output contains $label", ({ outputTail }) => {
+    const result = classifyOpenCodeResult(makeResult({ exitCode: 1, outputTail }));
+    expect(result.classification).toBe("unknown_failure");
+    expect(result.retryable).toBe(false);
+  });
+});
+
+describe("shouldRetryOpenCodeResult", () => {
+  it.each([
+    { exitCode: 1, outputTail: "stream ended unexpectedly", attempt: 1, maxAttempts: 2, expected: true, label: "transient within limit" },
+    { exitCode: 1, outputTail: "stream ended unexpectedly", attempt: 2, maxAttempts: 2, expected: false, label: "at limit" },
+    { exitCode: 124, outputTail: "", attempt: 1, maxAttempts: 2, expected: false, label: "non-retryable classification" },
+    { exitCode: 1, outputTail: "some error", attempt: 1, maxAttempts: 2, expected: false, label: "unknown failure" },
+  ])("$label", ({ exitCode, outputTail, attempt, maxAttempts, expected }) => {
+    const result = makeResult({ exitCode, outputTail, attempt });
+    expect(shouldRetryOpenCodeResult(result, maxAttempts)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runOpenCode — tested with real ReadableStream test doubles
+// ---------------------------------------------------------------------------
+
+describe("runOpenCode", () => {
+  it("captures stdout and stderr output", async () => {
+    const result = await runOpenCode(spawnTestDouble("hello stdout\n", "hello stderr\n", 0));
+    expect(result.exitCode).toBe(0);
+    expect(result.outputTail).toContain("hello stdout");
+    expect(result.outputTail).toContain("hello stderr");
+  });
+
+  it("slices oversized output to preserve the tail", async () => {
+    const oversized = "a".repeat(OUTPUT_TAIL_LIMIT + 1000);
+    const result = await runOpenCode(spawnTestDouble(oversized, "", 1));
+    expect(result.outputTail.length).toBe(OUTPUT_TAIL_LIMIT);
+    expect(result.outputTail).toBe("a".repeat(OUTPUT_TAIL_LIMIT));
+  });
+
+  it("waits for stdout and stderr to drain before resolving", async () => {
+    const result = await runOpenCode(
+      spawnTestDouble("final stdout line", "final stderr line", 1),
+    );
+    expect(result.outputTail).toContain("final stdout line");
+    expect(result.outputTail).toContain("final stderr line");
+  });
+
+  it("returns error output when spawn fails", async () => {
+    const throwingSpawn: SpawnFn = () => {
+      throw new Error("spawn failed");
+    };
+    const result = await runOpenCode(throwingSpawn);
+    expect(result.exitCode).toBe(1);
+    expect(result.outputTail).toContain("spawn failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// main retry loop — tested with real functions, not vi.fn mocks
+// ---------------------------------------------------------------------------
+
+describe("main", () => {
+  beforeEach(() => {
+    // core.setOutput uses appendFileSync on GITHUB_OUTPUT. The Workers
+    // test environment does not support filesystem append, so we spy on
+    // setOutput to capture writes in memory. This is the only mock in the
+    // test suite — all other tests exercise real code paths.
+    vi.restoreAllMocks();
+    vi.spyOn(core, "setOutput").mockImplementation(() => {});
+  });
+
+  it("succeeds on first attempt", async () => {
+    const run = async () => ({
+      exitCode: 0,
+      signal: null,
+      outputTail: "success",
+    });
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve("abc1234");
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(0);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "0");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "success");
+  });
+
+  it("retries transient failure then succeeds", async () => {
+    let callCount = 0;
+    const run = async () => {
+      callCount++;
+      if (callCount === 1) {
+        return runOpenCode(
+          spawnTestDouble("Error: The operation was canceled", "", 1),
+        );
+      }
+      return runOpenCode(spawnTestDouble("success", "", 0));
+    };
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve("abc1234");
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(0);
+    expect(callCount).toBe(2);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "0");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "2");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "success");
+  });
+
+  it("does not retry when workspace is dirty", async () => {
+    const run = async () =>
+      runOpenCode(spawnTestDouble("Error: The operation was canceled", "", 1));
+    const clean = () => Promise.resolve(false);
+    const headSha = () => Promise.resolve("abc1234");
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(1);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "transient_but_workspace_dirty");
+  });
+
+  it("does not retry when HEAD moved but workspace is clean", async () => {
+    let callCount = 0;
+    const run = async () => {
+      callCount++;
+      return runOpenCode(spawnTestDouble("Error: The operation was canceled", "", 1));
+    };
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve(callCount === 1 ? "abc1234" : "def5678");
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(1);
+    expect(callCount).toBe(1);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "transient_but_head_moved");
+  });
+
+  it("does not retry when HEAD cannot be determined", async () => {
+    const run = async () =>
+      runOpenCode(spawnTestDouble("Error: The operation was canceled", "", 1));
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve(null);
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(1);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "transient_but_head_unknown");
+  });
+
+  it("does not retry non-retryable failure", async () => {
+    const run = async () => ({
+      exitCode: 127,
+      signal: null,
+      outputTail: "",
+    });
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve("abc1234");
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(127);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "127");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "command not found");
+  });
+
+  it("handles unexpected errors from runOpenCode", async () => {
+    const run = async () => {
+      throw new Error("spawn failed");
+    };
+    const clean = () => Promise.resolve(true);
+    const headSha = () => Promise.resolve("abc1234");
+
+    const exitCode = await main(run, clean, headSha);
+    expect(exitCode).toBe(1);
+
+    expect(core.setOutput).toHaveBeenCalledWith("exit_code", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("attempt_count", "1");
+    expect(core.setOutput).toHaveBeenCalledWith("final_reason", "unexpected_error: spawn failed");
+  });
+});

--- a/test/run-opencode.spec.ts
+++ b/test/run-opencode.spec.ts
@@ -69,6 +69,31 @@ function spawnSignalTestDouble(signalCode: string): SpawnFn {
   });
 }
 
+function spawnDelayedSignalTestDouble(signalCode: string): SpawnFn {
+  return () => {
+    let exited = false;
+    return {
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      }),
+      exited: Promise.resolve().then(() => {
+        exited = true;
+        return 137;
+      }),
+      get signalCode() {
+        return exited ? signalCode : null;
+      },
+    };
+  };
+}
+
 // ---------------------------------------------------------------------------
 // OpenCode Run Classification
 // ---------------------------------------------------------------------------
@@ -90,13 +115,7 @@ describe("classifyOpenCodeResult", () => {
 
   it.each([
     { exitCode: 1, outputTail: "some error", classification: "unknown_failure", retryable: false, label: "unknown failure" },
-    { exitCode: 1, outputTail: "Error: The operation was canceled", classification: "transient", retryable: true, label: "transient pattern" },
     { exitCode: 1, outputTail: "stream ended unexpectedly (provider: openai)", classification: "transient", retryable: true, label: "stream ended" },
-    { exitCode: 1, outputTail: "Error: fetch failed: 502", classification: "transient", retryable: true, label: "fetch failure" },
-    { exitCode: 1, outputTail: "Error: HTTP 429", classification: "transient", retryable: true, label: "rate limit" },
-    { exitCode: 1, outputTail: "Error: HTTP 503", classification: "transient", retryable: true, label: "503" },
-    { exitCode: 1, outputTail: "Error: ECONNRESET", classification: "transient", retryable: true, label: "network error" },
-    { exitCode: 1, outputTail: "Error [ERR_STREAM_ABORT]: aborted", classification: "transient", retryable: true, label: "ERR_STREAM_ABORT" },
   ])("exit %d with %s → %s", ({ exitCode, outputTail, classification, retryable }) => {
     const result = classifyOpenCodeResult(makeResult({ exitCode, outputTail }));
     expect(result.classification).toBe(classification);
@@ -106,6 +125,11 @@ describe("classifyOpenCodeResult", () => {
   // Negative tests: every pattern must NOT match ordinary repo/test/tool output.
   it.each([
     { outputTail: "Test output: 500 Internal Server Error", label: "HTTP 500 in test output" },
+    { outputTail: "Error: fetch failed", label: "exact generic fetch failure" },
+    { outputTail: "Error: HTTP 500", label: "exact generic HTTP 500" },
+    { outputTail: "Error: HTTP 503", label: "exact generic HTTP 503" },
+    { outputTail: "Error: ECONNRESET", label: "exact generic ECONNRESET" },
+    { outputTail: "Error: The operation was canceled", label: "generic cancellation" },
     { outputTail: "Expected fetch failed", label: "fetch failed without Error: prefix" },
     { outputTail: "error: fetch failed in mock test", label: "lowercase error prefix" },
     { outputTail: "The operation was canceled", label: "The operation was canceled without Error: prefix" },
@@ -163,6 +187,12 @@ describe("runOpenCode", () => {
     expect(result.signal).toBe("SIGKILL");
   });
 
+  it("reads signal termination metadata after the process exits", async () => {
+    const result = await runOpenCode(spawnDelayedSignalTestDouble("SIGKILL"));
+    expect(result.exitCode).toBe(137);
+    expect(result.signal).toBe("SIGKILL");
+  });
+
   it("slices oversized output to preserve the tail", async () => {
     const oversized = "a".repeat(OUTPUT_TAIL_LIMIT + 1000);
     const result = await runOpenCode(spawnTestDouble(oversized, "", 1));
@@ -205,6 +235,7 @@ describe("main", () => {
   it("succeeds on first attempt", async () => {
     const run = async () => ({
       exitCode: 0,
+      signal: null,
       outputTail: "success",
     });
     const clean = () => Promise.resolve(true);
@@ -224,7 +255,7 @@ describe("main", () => {
       callCount++;
       if (callCount === 1) {
         return runOpenCode(
-          spawnTestDouble("Error: The operation was canceled", "", 1),
+          spawnTestDouble("stream ended unexpectedly (provider: openai)", "", 1),
         );
       }
       return runOpenCode(spawnTestDouble("success", "", 0));
@@ -243,7 +274,7 @@ describe("main", () => {
 
   it("does not retry when workspace is dirty", async () => {
     const run = async () =>
-      runOpenCode(spawnTestDouble("Error: The operation was canceled", "", 1));
+      runOpenCode(spawnTestDouble("stream ended unexpectedly (provider: openai)", "", 1));
     const clean = () => Promise.resolve(false);
     const headSha = () => Promise.resolve("abc1234");
 
@@ -259,7 +290,7 @@ describe("main", () => {
     let callCount = 0;
     const run = async () => {
       callCount++;
-      return runOpenCode(spawnTestDouble("Error: The operation was canceled", "", 1));
+      return runOpenCode(spawnTestDouble("stream ended unexpectedly (provider: openai)", "", 1));
     };
     const clean = () => Promise.resolve(true);
     const headSha = () => Promise.resolve(callCount === 1 ? "abc1234" : "def5678");
@@ -275,7 +306,7 @@ describe("main", () => {
 
   it("does not retry when HEAD cannot be determined", async () => {
     const run = async () =>
-      runOpenCode(spawnTestDouble("Error: The operation was canceled", "", 1));
+      runOpenCode(spawnTestDouble("stream ended unexpectedly (provider: openai)", "", 1));
     const clean = () => Promise.resolve(true);
     const headSha = () => Promise.resolve(null);
 


### PR DESCRIPTION
## Summary

Replaces the inline `timeout 45m opencode github run` shell block with a typed wrapper that retries once for provider-owned OpenCode failures while preserving the existing finalisation contract.

Mitigates #182. This is a bounded mitigation, not a root-cause fix — see 'Known limitation' below.

## Problem

When the upstream provider drops or cancels during `opencode github run`, the Action step exits non-zero and the workflow finalizes the run as failed. There is no recovery path for transient provider blips — the user must manually rerun.

## What changed

### Execution wrapper (`github/script/run-opencode.ts`)

- Runs `timeout 45m opencode github run` via `Bun.spawn`
- Streams stdout/stderr to the Action log in real time
- Keeps a 64KB byte-capped tail of combined output for classification
- Classifies exit code + output tail against known provider-owned failure patterns
- Retries at most once for retryable classifications
- Before retrying: verifies git working tree is clean and HEAD has not moved (fail-closed)
- Writes `exit_code`, `attempt_count`, and `final_reason` to `GITHUB_OUTPUT`

### Retry metadata plumbing (`action.yml` → `finalize.ts` → `src/types.ts` → `src/agent.ts`)

Retry metadata flows through the finalize step so the server can log success-after-retry, transient failures, and dirty-workspace refusals. No behaviour change — logging only.

### Transient classifier

Retryable patterns are matched line-by-line and only for unknown exit codes. Each match carries a named reason:

- `provider_stream_ended` — `^.*stream ended unexpectedly \(provider:.*$`
- `provider_operation_canceled` — `^(Error: )?The operation was canceled\.$`

The `provider_operation_canceled` pattern matches the observed OpenCode stderr line `The operation was canceled.` (with optional `Error: ` prefix). It is intentionally scoped to whole-line matches so ordinary repo/test output like `Test expected "The operation was canceled."` does not trigger a retry.

Known GitHub Actions termination codes take precedence (timeout `124`, SIGINT `130`, SIGKILL `137`, SIGTERM `143`), so real workflow cancellations are never retried. Generic network errors (`Error: fetch failed`, `ECONNRESET`, HTTP 5xx, etc.) and normal repo/test/tool output are intentionally not retry signals. Negative tests cover each of those cases.

### Test coverage

Split `test/github-script.spec.ts` into `test/context.spec.ts`, `test/http.spec.ts`, and `test/run-opencode.spec.ts` (175 tests, all passing).

## Known limitation

This PR mitigates by parsing OpenCode output. The real fix belongs upstream: OpenCode should expose a machine-readable retry signal (distinct exit code, JSON summary, or prefixed error line). Upstream tracking issue: anomalyco/opencode#32633

The retry guard only checks git state (working tree clean? HEAD unchanged?). It cannot detect GitHub-side effects made by the agent such as comments, reviews, labels, or API calls. A fully robust solution would require idempotency or a 'side effects started' signal from OpenCode. The current trade-off: the retryable failures occur during the LLM call before tool execution starts, so the retry covers the common case. API-side effects after tool execution are the gap — documented in code and accepted as a deliberate trade-off.

## Files changed

- `github/script/run-opencode.ts` — new wrapper
- `github/action.yml` — wire wrapper into step 6
- `github/script/finalize.ts` — read retry metadata env vars
- `github/script/context.ts` — `getErrorMessage()` utility
- `github/script/orchestrate.ts` — use `getErrorMessage()`
- `src/types.ts` — optional retry fields on `FinalizeWorkflowRequest`
- `src/agent.ts` — log retry metadata
- `src/index.ts` — pass retry fields to agent
- `test/run-opencode.spec.ts` — wrapper tests
- `test/context.spec.ts` — split from `github-script.spec.ts`
- `test/http.spec.ts` — split from `github-script.spec.ts`

