### PR TITLE
Default OpenCode title agent to Bonk model

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -193,6 +193,23 @@ runs:
       id: opencode
       shell: bash
       run: |
+        set -e
+        # OpenCode's opencode provider currently picks gpt-5-nano for the hidden
+        # title agent. That model can be disabled, so default title generation to
+        # the requested Bonk model while still allowing project config to override.
+        if [[ "${MODEL}" == opencode/* && -z "${OPENCODE_CONFIG:-}" ]]; then
+          BONK_OPENCODE_CONFIG="$(mktemp)"
+          export BONK_OPENCODE_CONFIG
+          bun -e '
+            const config = {
+              "$schema": "https://opencode.ai/config.json",
+              agent: { title: { model: process.env.MODEL } },
+            };
+            await Bun.write(process.env.BONK_OPENCODE_CONFIG, JSON.stringify(config, null, 2));
+          '
+          export OPENCODE_CONFIG="${BONK_OPENCODE_CONFIG}"
+        fi
+
         set +e
         # GH_TOKEN is the App token written to GITHUB_ENV by the OIDC exchange step.
         export USE_GITHUB_TOKEN=true


### PR DESCRIPTION
Fix OpenCode-provider Bonk runs whose hidden title-generation request can fail before the main model completes.

OpenCode now auto-selects `opencode/gpt-5-nano` for the hidden `title` agent. In Zen that model can be disabled, so runs configured with `opencode/gpt-5.5` still start a failing secondary stream even though the primary `build` agent uses the requested model.

- write a temporary OpenCode config for `opencode/*` action runs
- set only `agent.title.model` to the workflow `model` input
- use `OPENCODE_CONFIG` rather than inline config so repository config can still override the title model

Tests: `bun run tsc --noEmit`, `bun run test`, `bun run lint`