### PR TITLE
Harden GitHub Action CODEOWNERS checks

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -22,10 +22,6 @@ jobs:
 
       - run: git fetch --force --tags
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3"
-
       - name: Publish
         run: |
           git config --global user.email "ask-bonk[bot]@users.noreply.github.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Type check
         run: bun run tsc --noEmit
 
+      - name: Type check GitHub Action scripts
+        run: bun run typecheck:action
+
       - name: Run tests
         run: bun run test
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -397,6 +397,9 @@ async function runWorkflow(
       PROMPT: config.prompt || "",
       CRON: config.cron || "0 0 * * 1",
       PERMISSIONS: config.permissions,
+      ACTION_PERMISSIONS: config.permissions === "read" ? "write" : config.permissions,
+      TOKEN_PERMISSIONS_INPUT:
+        config.permissions === "read" ? "          token_permissions: NO_PUSH" : "",
       BOT_COMMAND,
       BOT_MENTION,
       EVENTS: config.events

--- a/cli/templates/custom.yml.hbs
+++ b/cli/templates/custom.yml.hbs
@@ -30,7 +30,8 @@ jobs:
         with:
           model: "{{MODEL}}"
           mentions: "{{MENTIONS}}"
-          permissions: {{PERMISSIONS}}
+          permissions: {{ACTION_PERMISSIONS}}
+{{TOKEN_PERMISSIONS_INPUT}}
           # opencode_version: "1.2.16"  # Pin to a specific OpenCode version (default: latest)
           prompt: |
             {{PROMPT}}

--- a/github/action.yml
+++ b/github/action.yml
@@ -169,8 +169,12 @@ runs:
         echo "opencode version: $(opencode version 2>/dev/null || echo 'unknown')"
 
     - name: Configure Git
-      if: success() && steps.mentions.outputs.skip != 'true' && steps.preflight.outputs.skip != 'true'
+      if: |
+        success() && steps.mentions.outputs.skip != 'true' && steps.preflight.outputs.skip != 'true'
+        && steps.preflight.outputs.is_fork != 'true'
       shell: bash
+      env:
+        GH_TOKEN: ${{ steps.preflight.outputs.gh_token }}
       run: |
         git config --global user.name "ask-bonk[bot]"
         git config --global user.email "ask-bonk[bot]@users.noreply.github.com"
@@ -178,13 +182,26 @@ runs:
         # local git config. Pushes authenticated with GITHUB_TOKEN don't trigger
         # downstream workflows (by design). The App installation token obtained
         # via OIDC exchange does trigger them.
-        if [ -n "${GH_TOKEN}" ]; then
+        if [ -n "${GH_TOKEN:-}" ]; then
           server_url="${GITHUB_SERVER_URL:-https://github.com}"
           host="${server_url#https://}"
           host="${host#http://}"
           git config --unset-all "http.${server_url}/.extraheader" 2>/dev/null || true
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@${host}/${GITHUB_REPOSITORY}.git"
         fi
+
+    - name: Clear Git credentials for fork
+      if: |
+        success() && steps.mentions.outputs.skip != 'true' && steps.preflight.outputs.skip != 'true'
+        && steps.preflight.outputs.is_fork == 'true' && steps.preflight.outputs.run_opencode == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        server_url="${GITHUB_SERVER_URL:-https://github.com}"
+        host="${server_url#https://}"
+        host="${host#http://}"
+        git config --unset-all "http.${server_url}/.extraheader" 2>/dev/null || true
+        git remote set-url origin "https://${host}/${GITHUB_REPOSITORY}.git" 2>/dev/null || true
 
     - name: Run opencode
       if: |
@@ -198,6 +215,7 @@ runs:
         AGENT: ${{ inputs.agent }}
         VARIANT: ${{ inputs.variant }}
         PROMPT: ${{ steps.preflight.outputs.value }}
+        GH_TOKEN: ${{ steps.preflight.outputs.gh_token }}
         SHARE: false
         MENTIONS: ${{ inputs.mentions }}
         OIDC_BASE_URL: ${{ inputs.oidc_base_url }}
@@ -227,3 +245,14 @@ runs:
         # when the run was never tracked or was already removed from activeRuns.
         ISSUE_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
       run: bun run ${{ github.action_path }}/script/finalize.ts
+
+    - name: Cleanup Git credentials
+      if: always() && steps.mentions.outputs.skip != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        server_url="${GITHUB_SERVER_URL:-https://github.com}"
+        host="${server_url#https://}"
+        host="${host#http://}"
+        git config --unset-all "http.${server_url}/.extraheader" 2>/dev/null || true
+        git remote set-url origin "https://${host}/${GITHUB_REPOSITORY}.git" 2>/dev/null || true

--- a/github/script/bun.d.ts
+++ b/github/script/bun.d.ts
@@ -1,0 +1,16 @@
+interface BunSubprocess {
+  pid: number;
+  stdout: ReadableStream<Uint8Array> | null;
+  stderr: ReadableStream<Uint8Array> | null;
+  exited: Promise<number>;
+  kill: (signal?: NodeJS.Signals | number) => void;
+}
+
+declare const Bun: {
+  spawn(command: string[], options: {
+    detached?: boolean;
+    env?: NodeJS.ProcessEnv;
+    stdout: "pipe" | "ignore";
+    stderr: "pipe" | "ignore";
+  }): BunSubprocess;
+};

--- a/github/script/context.ts
+++ b/github/script/context.ts
@@ -4,6 +4,9 @@
 import { appendFileSync } from "fs";
 import { fetchWithRetry } from "./http";
 
+const DEFAULT_OIDC_AUDIENCE = "opencode-github-action";
+const oidcTokenCache = new Map<string, Promise<string>>();
+
 export interface Repo {
   owner: string;
   repo: string;
@@ -138,7 +141,10 @@ export const core: Core = {
 };
 
 // Get OIDC token from GitHub Actions
-export async function getOidcToken(audience: string = "opencode-github-action"): Promise<string> {
+export async function getOidcToken(audience: string = DEFAULT_OIDC_AUDIENCE): Promise<string> {
+  const cached = oidcTokenCache.get(audience);
+  if (cached) return cached;
+
   const requestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
   const requestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
 
@@ -146,20 +152,33 @@ export async function getOidcToken(audience: string = "opencode-github-action"):
     throw new Error("OIDC token request credentials not available");
   }
 
-  const response = await fetchWithRetry(`${requestUrl}&audience=${audience}`, {
-    headers: { Authorization: `bearer ${requestToken}` },
-  });
+  const tokenPromise = (async () => {
+    const url = new URL(requestUrl);
+    url.searchParams.set("audience", audience);
 
-  if (!response.ok) {
-    throw new Error(`Failed to get OIDC token: ${response.status}`);
+    const response = await fetchWithRetry(url.toString(), {
+      headers: { Authorization: `bearer ${requestToken}` },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to get OIDC token: ${response.status}`);
+    }
+
+    const data = (await response.json()) as { value?: string };
+    if (!data.value) {
+      throw new Error("OIDC token response missing value");
+    }
+
+    return data.value;
+  })();
+
+  oidcTokenCache.set(audience, tokenPromise);
+  try {
+    return await tokenPromise;
+  } catch (error) {
+    oidcTokenCache.delete(audience);
+    throw error;
   }
-
-  const data = (await response.json()) as { value?: string };
-  if (!data.value) {
-    throw new Error("OIDC token response missing value");
-  }
-
-  return data.value;
 }
 
 // Get API base URL from OIDC base URL
@@ -168,10 +187,22 @@ export function getApiBaseUrl(): string {
   if (!oidcBaseUrl) {
     throw new Error("OIDC_BASE_URL not set");
   }
-  const normalized = oidcBaseUrl.replace(/\/+$/, "");
-  if (!normalized.startsWith("https://")) {
+  if (oidcBaseUrl.includes("?") || oidcBaseUrl.includes("#")) {
+    throw new Error("OIDC_BASE_URL must not include credentials, query, or fragment");
+  }
+  let url: URL;
+  try {
+    url = new URL(oidcBaseUrl);
+  } catch {
+    throw new Error("OIDC_BASE_URL must be a valid URL");
+  }
+  if (url.protocol !== "https:") {
     throw new Error("OIDC_BASE_URL must use https");
   }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("OIDC_BASE_URL must not include credentials, query, or fragment");
+  }
+  const normalized = url.toString().replace(/\/+$/, "");
   return normalized.replace(/\/auth$/, "");
 }
 

--- a/github/script/http.ts
+++ b/github/script/http.ts
@@ -39,7 +39,7 @@ function parseRetryAfterMs(response: Response): number {
   return Math.min(seconds * 1000, MAX_RETRY_DELAY_MS);
 }
 
-export async function fetchWithTimeout(
+async function fetchWithTimeout(
   url: string,
   options: RequestInit,
   timeoutMs: number,

--- a/github/script/orchestrate.ts
+++ b/github/script/orchestrate.ts
@@ -10,6 +10,7 @@
 
 import { readFileSync } from "fs";
 import { join } from "path";
+import { pathToFileURL } from "url";
 import {
   getContext,
   getOidcToken,
@@ -19,7 +20,6 @@ import {
   validateOpenCodeVersion,
   checkPermissionLevel,
   extractMentionPrompt,
-  appendGitHubValue,
   core,
 } from "./context";
 import { fetchWithRetry } from "./http";
@@ -29,13 +29,40 @@ import { fetchWithRetry } from "./http";
 // ---------------------------------------------------------------------------
 
 const CODEOWNERS_PATHS = [".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS"];
+const ESCAPED_CODEOWNERS_CHAR = "\u0000";
 
 interface ContentResponse {
   content: string;
 }
 
-interface TeamMembershipResponse {
-  state?: string;
+interface PullRequestFileResponse {
+  filename: string;
+  previous_filename?: string;
+}
+
+interface ChangedFilesResult {
+  paths: string[];
+  recordCount: number;
+}
+
+interface CodeownersCheckResult {
+  teamGroups: string[][];
+}
+
+interface PullRequestResponse {
+  changed_files?: number;
+  base?: {
+    ref?: string;
+    sha?: string;
+  };
+}
+
+interface CodeownersRule {
+  pattern: string;
+  owners: string[];
+  teams: string[];
+  unsupportedOwners: string[];
+  unsupportedPattern: boolean;
 }
 
 async function githubApi<T>(path: string, token: string): Promise<T | null> {
@@ -52,92 +79,305 @@ async function githubApi<T>(path: string, token: string): Promise<T | null> {
   return (await resp.json()) as T;
 }
 
-function parseCodeowners(content: string): {
-  owners: Set<string>;
-  teamPatterns: string[];
-} {
-  const owners = new Set<string>();
-  const teamPatterns: string[] = [];
+export function parseCodeowners(content: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
 
   for (const line of content.split("\n")) {
-    const trimmed = (line.split("#", 1)[0] || "").trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
+    const fields = splitCodeownersLine(line);
+    if (fields.length < 1) continue;
 
-    const fields = trimmed.split(/\s+/);
-    if (fields.length < 2) continue;
-
-    const mentions = fields.slice(1).filter((field) => /^@[\w-]+(?:\/[\w-]+)?$/.test(field));
-    for (const mention of mentions) {
-      if (mention.includes("/")) {
-        teamPatterns.push(mention.substring(1));
+    const owners: string[] = [];
+    const teams: string[] = [];
+    const unsupportedOwners: string[] = [];
+    for (const ownerField of fields.slice(1)) {
+      if (/^@[\w-]+(?:\/[\w-]+)?$/.test(ownerField)) {
+        if (ownerField.includes("/")) {
+          teams.push(ownerField.substring(1).toLowerCase());
+        } else {
+          owners.push(ownerField.substring(1).toLowerCase());
+        }
       } else {
-        owners.add(mention.substring(1).toLowerCase());
+        unsupportedOwners.push(ownerField);
       }
+    }
+
+    rules.push({
+      pattern: fields[0],
+      owners,
+      teams,
+      unsupportedOwners,
+      unsupportedPattern: hasUnsupportedCodeownersPattern(fields[0]),
+    });
+  }
+
+  return rules;
+}
+
+function splitCodeownersLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let escaped = false;
+
+  for (const char of line.trim()) {
+    if (escaped) {
+      current += `${ESCAPED_CODEOWNERS_CHAR}${char}`;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (char === "#" && !current) break;
+    if (/\s/.test(char)) {
+      if (current) {
+        fields.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (escaped) current += "\\";
+  if (current) fields.push(current);
+  return fields;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.*]/g, "\\$&");
+}
+
+function hasUnsupportedCodeownersPattern(pattern: string): boolean {
+  if (pattern.startsWith("!")) return true;
+  if (pattern.startsWith(`${ESCAPED_CODEOWNERS_CHAR}#`)) return true;
+  for (let index = 0; index < pattern.length; index += 1) {
+    if (pattern[index] === ESCAPED_CODEOWNERS_CHAR) {
+      index += 1;
+      continue;
+    }
+    if (pattern[index] === "[" || pattern[index] === "]") return true;
+  }
+  return false;
+}
+
+function hasLiteralDirectoryChars(segment: string): boolean {
+  for (let index = 0; index < segment.length; index += 1) {
+    if (segment[index] === ESCAPED_CODEOWNERS_CHAR) {
+      index += 1;
+      continue;
+    }
+    if (segment[index] !== "*" && segment[index] !== "?") return true;
+  }
+  return false;
+}
+
+function codeownersPatternToRegex(pattern: string): RegExp | null {
+  if (!pattern || pattern.startsWith("!")) return null;
+
+  const anchored = pattern.startsWith("/");
+  const directoryPattern = pattern.endsWith("/");
+  let normalized = pattern.replace(/^\/+/, "");
+  if (!normalized) return null;
+  const slashlessPattern = !normalized.replace(/\/+$/, "").includes("/");
+  if (directoryPattern) normalized += "**";
+  const finalSegment = normalized.split("/").at(-1) || "";
+  const finalSegmentCanBeDirectory = hasLiteralDirectoryChars(finalSegment);
+  const descendantMatch =
+    !directoryPattern && (!/[*?]/.test(finalSegment) || finalSegmentCanBeDirectory);
+  const anyParentPrefix =
+    !anchored && (slashlessPattern || normalized.startsWith("**/"));
+
+  let source = "";
+  for (let index = 0; index < normalized.length; ) {
+    if (normalized[index] === ESCAPED_CODEOWNERS_CHAR) {
+      const escapedChar = normalized[index + 1] || "";
+      source += escapeRegex(escapedChar);
+      index += escapedChar ? 2 : 1;
+      continue;
+    }
+    if (normalized.startsWith("**/", index)) {
+      source += "(?:.*/)?";
+      index += 3;
+      continue;
+    }
+    if (normalized.startsWith("**", index) && index + 2 === normalized.length && normalized[index - 1] === "/") {
+      source += ".*";
+      index += 2;
+      continue;
+    }
+    const char = normalized[index];
+    if (char === "*") {
+      source += "[^/]*";
+      index += 1;
+    } else if (char === "?") {
+      source += "[^/]";
+      index += 1;
+    } else {
+      source += escapeRegex(char);
+      index += 1;
     }
   }
 
-  return { owners, teamPatterns };
+  source = anyParentPrefix ? `(?:^|.*/)${source}` : `^${source}`;
+  if (descendantMatch) source += "(?:/.*)?";
+  return new RegExp(`${source}$`);
 }
 
-async function checkCodeowners(
+export function findMatchingCodeownersRule(
+  rules: CodeownersRule[],
+  filename: string,
+): CodeownersRule | null {
+  let matched: CodeownersRule | null = null;
+  for (const rule of rules) {
+    const regex = codeownersPatternToRegex(rule.pattern);
+    if (regex?.test(filename)) {
+      matched = rule;
+    }
+  }
+  return matched;
+}
+
+async function listChangedFiles(
+  owner: string,
+  repo: string,
+  prNumber: string,
+  token: string,
+): Promise<ChangedFilesResult> {
+  const filenames = new Set<string>();
+  let recordCount = 0;
+  for (let page = 1; ; page += 1) {
+    const files = await githubApi<PullRequestFileResponse[]>(
+      `/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`,
+      token,
+    );
+    if (!files) return { paths: [], recordCount: 0 };
+    recordCount += files.length;
+    for (const file of files) {
+      if (file.filename) filenames.add(file.filename);
+      if (file.previous_filename) filenames.add(file.previous_filename);
+    }
+    if (files.length < 100) break;
+  }
+  return { paths: Array.from(filenames), recordCount };
+}
+
+async function actorHasWritePermission(
+  owner: string,
+  repo: string,
+  actor: string,
+  token: string,
+): Promise<boolean> {
+  const data = await githubApi<{ permission: string }>(
+    `/repos/${owner}/${repo}/collaborators/${actor}/permission`,
+    token,
+  );
+  return Boolean(data && !checkPermissionLevel(data.permission, "write", actor));
+}
+
+function actorOwnsRule(rule: CodeownersRule, actor: string): boolean {
+  const actorLower = actor.toLowerCase();
+  return rule.owners.includes(actorLower);
+}
+
+export async function checkCodeowners(
   owner: string,
   repo: string,
   ref: string,
   actor: string,
   token: string,
-): Promise<void> {
+): Promise<CodeownersCheckResult> {
+  const prNumber = process.env.PR_NUMBER || process.env.ISSUE_NUMBER || "";
+  if (!prNumber) {
+    return core.setFailed("CODEOWNERS permission requires pull request context");
+  }
+
+  const pr = await githubApi<PullRequestResponse>(`/repos/${owner}/${repo}/pulls/${prNumber}`, token);
+  const codeownersRef = pr?.base?.sha || pr?.base?.ref;
+  if (!pr || !codeownersRef) {
+    return core.setFailed("CODEOWNERS permission could not determine PR base ref");
+  }
+
   let codeownersContent = "";
+  let codeownersFound = false;
 
   for (const path of CODEOWNERS_PATHS) {
     const data = await githubApi<ContentResponse>(
-      `/repos/${owner}/${repo}/contents/${path}?ref=${ref || "HEAD"}`,
+      `/repos/${owner}/${repo}/contents/${path}?ref=${codeownersRef || ref || "HEAD"}`,
       token,
     );
-    if (data?.content) {
-      codeownersContent = Buffer.from(data.content, "base64").toString("utf8");
+    if (data) {
+      codeownersFound = true;
+      codeownersContent = data.content
+        ? Buffer.from(data.content, "base64").toString("utf8")
+        : "";
       core.info(`Found CODEOWNERS at ${path}`);
       break;
     }
   }
 
-  if (!codeownersContent) {
+  if (!codeownersFound) {
     return core.setFailed("CODEOWNERS file not found in .github/, root, or docs/ directory");
   }
 
-  const { owners, teamPatterns } = parseCodeowners(codeownersContent);
-  const actorLower = actor.toLowerCase();
-
-  if (owners.has(actorLower)) {
-    core.info(`User ${actor} is a code owner`);
-    return;
+  const rules = parseCodeowners(codeownersContent);
+  if (rules.some((rule) => rule.unsupportedPattern)) {
+    return core.setFailed("CODEOWNERS file contains unsupported pattern syntax");
+  }
+  const changedFiles = await listChangedFiles(owner, repo, prNumber, token);
+  if (changedFiles.paths.length === 0) {
+    return core.setFailed("CODEOWNERS permission could not determine changed PR files");
+  }
+  if (pr.changed_files !== undefined && pr.changed_files > changedFiles.recordCount) {
+    return core.setFailed("CODEOWNERS permission could not inspect every changed PR file");
   }
 
-  for (const teamPath of teamPatterns) {
-    const [org, team] = teamPath.split("/");
-    try {
-      const membership = await githubApi<TeamMembershipResponse>(
-        `/orgs/${org}/teams/${team}/memberships/${actor}`,
-        token,
-      );
-      if (membership?.state === "active") {
-        core.info(`User ${actor} is a member of team @${teamPath}`);
-        return;
+  let hasWritePermission: boolean | undefined;
+  const teamGroups: string[][] = [];
+  for (const filename of changedFiles.paths) {
+    const rule = findMatchingCodeownersRule(rules, filename);
+    if (!rule) {
+      return core.setFailed(`No CODEOWNERS rule matched changed file ${filename}`);
+    }
+    if (rule.unsupportedOwners.length > 0) {
+      return core.setFailed(`Unsupported CODEOWNERS owner for changed file ${filename}`);
+    }
+    hasWritePermission ??= await actorHasWritePermission(owner, repo, actor, token);
+    if (rule.owners.length === 0 && rule.teams.length === 0) {
+      if (!hasWritePermission) {
+        return core.setFailed(`Ownerless CODEOWNERS rule for ${filename} requires write permission`);
       }
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      core.warning(`Could not check team membership for @${teamPath}: ${message}`);
+      continue;
+    }
+    if (!hasWritePermission) {
+      return core.setFailed(`User ${actor} must have write permission to satisfy CODEOWNERS`);
+    }
+    if (actorOwnsRule(rule, actor)) {
+      continue;
+    }
+    if (rule.teams.length > 0) {
+      teamGroups.push(rule.teams);
+      continue;
+    }
+    if (!actorOwnsRule(rule, actor)) {
+      return core.setFailed(`User ${actor} is not a CODEOWNER for changed file ${filename}`);
     }
   }
 
-  core.setFailed(`User ${actor} is not listed in CODEOWNERS`);
+  if (teamGroups.length > 0) {
+    core.info(`User ${actor} requires server-side CODEOWNERS team verification`);
+  } else {
+    core.info(`User ${actor} is a code owner for all changed files`);
+  }
+  return { teamGroups };
 }
 
-async function checkPermissions(): Promise<void> {
+async function checkPermissions(): Promise<CodeownersCheckResult | null> {
   const requiredPermission = process.env.REQUIRED_PERMISSION;
   if (!requiredPermission) {
     return core.setFailed("REQUIRED_PERMISSION not set");
   }
-  if (requiredPermission === "any") return;
+  if (requiredPermission === "any") return null;
 
   const token = process.env.GH_TOKEN;
   if (!token) {
@@ -155,8 +395,7 @@ async function checkPermissions(): Promise<void> {
   }
 
   if (requiredPermission === "CODEOWNERS") {
-    await checkCodeowners(owner, repo, ref, actor, token);
-    return;
+    return checkCodeowners(owner, repo, ref, actor, token);
   }
 
   const data = await githubApi<{ permission: string }>(
@@ -172,6 +411,7 @@ async function checkPermissions(): Promise<void> {
   if (error) {
     core.setFailed(error);
   }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -199,9 +439,7 @@ async function checkSetup(): Promise<boolean> {
       eventName === "issue_comment" ||
       eventName === "issues"
     ) {
-      core.setFailed("No issue number found for PR/issue event; cannot run setup check");
-      // core.setFailed calls process.exit(1), but TypeScript doesn't know that
-      return true;
+      return core.setFailed("No issue number found for PR/issue event; cannot run setup check");
     }
     core.info("No issue number found, skipping setup check");
     core.setOutput("skip", "false");
@@ -215,8 +453,7 @@ async function checkSetup(): Promise<boolean> {
     const oidcAvailable =
       !!process.env.ACTIONS_ID_TOKEN_REQUEST_URL && !!process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
     if (oidcAvailable) {
-      core.setFailed(`OIDC token exchange failed unexpectedly: ${error}`);
-      return true;
+      return core.setFailed(`OIDC token exchange failed unexpectedly: ${error}`);
     }
     core.warning("OIDC not available, skipping setup check");
     core.setOutput("skip", "false");
@@ -261,23 +498,20 @@ async function checkSetup(): Promise<boolean> {
       },
     );
   } catch (error) {
-    core.setFailed(`Setup request failed after ${setupRetries + 1} attempts: ${error}`);
-    return true;
+    return core.setFailed(`Setup request failed after ${setupRetries + 1} attempts: ${error}`);
   }
 
   core.info(`Setup check completed with status ${response.status}`);
 
   if (!response.ok) {
     const text = await response.text();
-    core.setFailed(`Setup request failed: ${text}`);
-    return true;
+    return core.setFailed(`Setup request failed: ${text}`);
   }
 
   const data = (await response.json()) as SetupResponse;
 
   if (data.error) {
-    core.setFailed(`Setup failed: ${data.error}`);
-    return true;
+    return core.setFailed(`Setup failed: ${data.error}`);
   }
 
   if (data.exists) {
@@ -430,7 +664,7 @@ interface PromptResult {
   value: string;
 }
 
-async function buildPrompt(): Promise<PromptResult> {
+export async function buildPrompt(): Promise<PromptResult> {
   const detection = await detectFork();
 
   const parts: string[] = [];
@@ -464,7 +698,7 @@ async function buildPrompt(): Promise<PromptResult> {
   const userPrompt = process.env.USER_PROMPT?.trim();
   if (userPrompt) {
     parts.push(userPrompt);
-  } else if (parts.length > 0) {
+  } else {
     const commentPrompt = extractMentionPrompt(
       process.env.COMMENT_BODY || process.env.REVIEW_BODY,
       process.env.MENTIONS,
@@ -487,6 +721,12 @@ async function buildPrompt(): Promise<PromptResult> {
 
 interface OidcResult {
   failed: boolean;
+  token?: string;
+}
+
+interface OidcExchangeOptions {
+  forceNoPush: boolean;
+  codeownersTeamGroups?: string[][];
 }
 
 function maskValue(value: string): void {
@@ -495,21 +735,12 @@ function maskValue(value: string): void {
   }
 }
 
-function appendToGithubEnv(name: string, value: string): void {
-  const envFile = process.env.GITHUB_ENV;
-  if (!envFile) {
-    core.warning("GITHUB_ENV not set; cannot export environment variable");
-    return;
-  }
-  appendGitHubValue(envFile, name, value);
-}
-
 function oidcFailClosed(reason: string): OidcResult {
   core.warning(`OIDC exchange failed: ${reason}`);
   return { failed: true };
 }
 
-async function exchangeOidc(): Promise<OidcResult> {
+async function exchangeOidc(options: OidcExchangeOptions): Promise<OidcResult> {
   const oidcUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL;
   const oidcRequestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
 
@@ -535,7 +766,9 @@ async function exchangeOidc(): Promise<OidcResult> {
   // Accepts a preset name (e.g., "NO_PUSH") or a JSON permissions object.
   const exchangeBody: Record<string, unknown> = {};
   const rawPermissions = process.env.TOKEN_PERMISSIONS;
-  if (rawPermissions?.trim()) {
+  if (options.forceNoPush) {
+    exchangeBody.permissions = "NO_PUSH";
+  } else if (rawPermissions?.trim()) {
     const parsed = parseTokenPermissions(rawPermissions);
     if (parsed !== undefined) {
       exchangeBody.permissions = parsed;
@@ -545,6 +778,14 @@ async function exchangeOidc(): Promise<OidcResult> {
       // Fail closed: send NO_PUSH so the server doesn't grant full defaults.
       core.warning(`Invalid TOKEN_PERMISSIONS JSON, falling back to NO_PUSH: ${rawPermissions}`);
       exchangeBody.permissions = "NO_PUSH";
+    }
+  }
+
+  if (options.codeownersTeamGroups && options.codeownersTeamGroups.length > 0) {
+    exchangeBody.codeowners_team_groups = options.codeownersTeamGroups;
+    const actor = process.env.COMMENT_ACTOR || process.env.REVIEW_ACTOR || process.env.GITHUB_ACTOR;
+    if (actor) {
+      exchangeBody.actor = actor;
     }
   }
 
@@ -585,8 +826,7 @@ async function exchangeOidc(): Promise<OidcResult> {
   }
 
   maskValue(appToken);
-  appendToGithubEnv("GH_TOKEN", appToken);
-  return { failed: false };
+  return { failed: false, token: appToken };
 }
 
 // ---------------------------------------------------------------------------
@@ -723,26 +963,12 @@ async function trackRun(): Promise<void> {
     created_at: context.createdAt,
   };
 
-  switch (context.eventName) {
-    case "issue_comment":
-      if (context.comment?.id) {
-        payload.comment_id = context.comment.id;
-      }
-      break;
-    case "pull_request_review_comment":
-      if (context.comment?.id) {
-        payload.review_comment_id = context.comment.id;
-      }
-      break;
-    case "issues":
-      if (context.issue?.number) {
-        payload.issue_id = context.issue.number;
-      }
-      break;
-    case "pull_request":
-      break;
-    case "pull_request_review":
-      break;
+  if (context.eventName === "issue_comment" && context.comment?.id) {
+    payload.comment_id = context.comment.id;
+  } else if (context.eventName === "pull_request_review_comment" && context.comment?.id) {
+    payload.review_comment_id = context.comment.id;
+  } else if (context.eventName === "issues") {
+    payload.issue_id = context.issue.number;
   }
 
   let response: Response;
@@ -782,26 +1008,35 @@ async function trackRun(): Promise<void> {
 
 async function main() {
   // Step 1: Check permissions (must pass before anything else)
-  await checkPermissions();
+  const codeownersCheck = await checkPermissions();
 
   // Step 2: Check setup (may skip remaining steps)
   const shouldSkip = await checkSetup();
   if (shouldSkip) return;
 
-  // Step 3: Resolve version (synchronous), then run prompt and OIDC exchange
-  // in parallel (they are independent of each other).
+  // Step 3: Resolve version, then build the prompt before exchanging the token
+  // so fork runs can request a comment-only installation token.
   resolveVersion();
 
-  const [promptResult, oidcResult] = await Promise.all([buildPrompt(), exchangeOidc()]);
+  const promptResult = await buildPrompt();
+
+  if (promptResult.detectionFailed) {
+    core.setOutput("is_fork", String(promptResult.isFork));
+    core.setOutput("value", promptResult.value);
+    return core.setFailed("Fork status could not be verified; refusing to proceed.");
+  }
+
+  const oidcResult = await exchangeOidc({
+    forceNoPush: promptResult.isFork,
+    codeownersTeamGroups: codeownersCheck?.teamGroups,
+  });
 
   // Set prompt outputs
   core.setOutput("is_fork", String(promptResult.isFork));
   core.setOutput("value", promptResult.value);
   core.setOutput("oidc_failed", oidcResult.failed ? "true" : "false");
-
-  if (promptResult.detectionFailed) {
-    core.setFailed("Fork status could not be verified; refusing to proceed.");
-    return;
+  if (oidcResult.token) {
+    core.setOutput("gh_token", oidcResult.token);
   }
 
   // Step 4: Handle fork PRs
@@ -812,14 +1047,15 @@ async function main() {
 
   // Step 5: Require OIDC for non-fork runs
   if (oidcResult.failed) {
-    core.setFailed("OIDC token exchange failed. Ensure id-token: write is configured.");
-    return;
+    return core.setFailed("OIDC token exchange failed. Ensure id-token: write is configured.");
   }
 
   // Step 6: Track the run
   await trackRun();
 }
 
-main().catch((error) => {
-  core.setFailed(`Orchestrator failed: ${error}`);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    core.setFailed(`Orchestrator failed: ${error}`);
+  });
+}

--- a/github/script/orchestrate.ts
+++ b/github/script/orchestrate.ts
@@ -334,6 +334,7 @@ export async function checkCodeowners(
 
   let hasWritePermission: boolean | undefined;
   const teamGroups: string[][] = [];
+  const teamGroupKeys = new Set<string>();
   for (const filename of changedFiles.paths) {
     const rule = findMatchingCodeownersRule(rules, filename);
     if (!rule) {
@@ -356,7 +357,11 @@ export async function checkCodeowners(
       continue;
     }
     if (rule.teams.length > 0) {
-      teamGroups.push(rule.teams);
+      const teamGroupKey = rule.teams.join("\0");
+      if (!teamGroupKeys.has(teamGroupKey)) {
+        teamGroupKeys.add(teamGroupKey);
+        teamGroups.push(rule.teams);
+      }
       continue;
     }
     if (!actorOwnsRule(rule, actor)) {

--- a/github/script/run-opencode.ts
+++ b/github/script/run-opencode.ts
@@ -7,10 +7,10 @@ const DEFAULT_TIMEOUT = "45m";
 const DEFAULT_RETRIES = 2;
 const DEFAULT_BASE_DELAY_MS = 15_000;
 const OUTPUT_TAIL_LIMIT = 64_000;
+const STREAM_DRAIN_GRACE_MS = 1_000;
 
 const NON_RETRYABLE_EXIT_CODES = new Set([
-  124, // GNU timeout: command timed out
-  125, // GNU timeout internal failure
+  124, // opencode run timed out
   126, // command found but not executable
   127, // command not found
   130, // SIGINT
@@ -64,6 +64,7 @@ function parseDurationMs(value: string): number | null {
     case "h":
       return amount * 60 * 60 * 1000;
   }
+  return null;
 }
 
 function parsePositiveInteger(value: string | undefined, fallback: number): number {
@@ -82,18 +83,40 @@ function rememberTail(current: string, chunk: string): string {
   return next.length > OUTPUT_TAIL_LIMIT ? next.slice(next.length - OUTPUT_TAIL_LIMIT) : next;
 }
 
+function killOpenCodeProcess(proc: BunSubprocess, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-proc.pid, signal);
+  } catch {
+    proc.kill(signal);
+  }
+}
+
 async function streamAndCapture(
   stream: ReadableStream<Uint8Array> | null,
   target: NodeJS.WriteStream,
+  signal?: AbortSignal,
 ): Promise<string> {
   if (!stream) return "";
 
   const decoder = new TextDecoder();
+  const reader = stream.getReader();
   let output = "";
+  const abort = () => {
+    void reader.cancel();
+  };
 
-  for await (const chunk of stream) {
-    target.write(chunk);
-    output = rememberTail(output, decoder.decode(chunk, { stream: true }));
+  signal?.addEventListener("abort", abort, { once: true });
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      target.write(value);
+      output = rememberTail(output, decoder.decode(value, { stream: true }));
+    }
+  } catch (error) {
+    if (!signal?.aborted) throw error;
+  } finally {
+    signal?.removeEventListener("abort", abort);
   }
 
   output = rememberTail(output, decoder.decode());
@@ -101,24 +124,52 @@ async function streamAndCapture(
 }
 
 async function runOpenCodeAttempt(timeoutMs: number): Promise<OpenCodeFailure> {
-  const timeoutSeconds = `${Math.max(1, Math.ceil(timeoutMs / 1000))}s`;
-  const proc = Bun.spawn(["timeout", timeoutSeconds, "opencode", "github", "run"], {
-    env: {
-      ...process.env,
-      USE_GITHUB_TOKEN: "true",
-      GITHUB_TOKEN: process.env.GH_TOKEN || "",
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([
-    streamAndCapture(proc.stdout, process.stdout),
-    streamAndCapture(proc.stderr, process.stderr),
-    proc.exited,
+  let timedOut = false;
+  const controller = new AbortController();
+  let proc: BunSubprocess;
+  try {
+    proc = Bun.spawn(["opencode", "github", "run"], {
+      detached: true,
+      env: {
+        ...process.env,
+        USE_GITHUB_TOKEN: "true",
+        GITHUB_TOKEN: process.env.GH_TOKEN || "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { exitCode: 127, output: error.message };
+    }
+    throw error;
+  }
+  const streamOutput = Promise.all([
+    streamAndCapture(proc.stdout, process.stdout, controller.signal),
+    streamAndCapture(proc.stderr, process.stderr, controller.signal),
   ]);
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    killOpenCodeProcess(proc, "SIGTERM");
+    killOpenCodeProcess(proc, "SIGKILL");
+    controller.abort();
+  }, Math.max(1, timeoutMs));
 
-  return { exitCode, output: `${stdout}\n${stderr}` };
+  try {
+    const exitCode = await proc.exited;
+    clearTimeout(timeout);
+
+    const drainGrace = setTimeout(() => {
+      killOpenCodeProcess(proc, "SIGTERM");
+      killOpenCodeProcess(proc, "SIGKILL");
+      controller.abort();
+    }, STREAM_DRAIN_GRACE_MS);
+    const [stdout, stderr] = await streamOutput.finally(() => clearTimeout(drainGrace));
+
+    return { exitCode: timedOut ? 124 : exitCode, output: `${stdout}\n${stderr}` };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 function writeExitCode(exitCode: number): void {
@@ -131,6 +182,12 @@ async function sleep(ms: number): Promise<void> {
 }
 
 export async function runOpenCodeWithRetry(): Promise<number> {
+  if (process.platform === "win32") {
+    console.error("Bonk GitHub Action requires a Linux or macOS runner.");
+    writeExitCode(126);
+    return 126;
+  }
+
   const timeoutMs = parseDurationMs(process.env.OPENCODE_TIMEOUT || DEFAULT_TIMEOUT) ??
     parseDurationMs(DEFAULT_TIMEOUT)!;
   const retries = parsePositiveInteger(process.env.OPENCODE_RETRIES, DEFAULT_RETRIES);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "deploy": "flue build --target cloudflare && wrangler deploy --config dist/ask_bonk/wrangler.json --var BONK_VERSION:\"$(git describe --tags --always)\" --var BONK_COMMIT:\"$(git rev-parse --short HEAD)\"",
     "dev": "flue dev --target cloudflare",
     "test": "vitest",
+    "typecheck:action": "tsc --noEmit -p tsconfig.github-action.json",
     "cf-typegen": "wrangler types",
     "cli:build": "bun build cli/index.ts --compile --outfile cli/bonk",
     "cli": "bun run cli/index.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -148,8 +148,13 @@ auth.post("/exchange_github_app_token", async (c) => {
   const authHeader = c.req.header("Authorization") ?? null;
 
   // Body is optional — callers may include { permissions } to scope the token.
-  // Accepts a preset name ("NO_PUSH", "WRITE") or a custom permissions object.
-  let body: { permissions?: import("./oidc").TokenPermissionsInput } = {};
+  // CODEOWNERS team groups are verified server-side because github.token does
+  // not have the org membership scope required for team membership APIs.
+  let body: {
+    permissions?: import("./oidc").TokenPermissionsInput;
+    codeowners_team_groups?: string[][];
+    actor?: string;
+  } = {};
   try {
     body = await c.req.json();
   } catch {

--- a/src/app.ts
+++ b/src/app.ts
@@ -150,11 +150,7 @@ auth.post("/exchange_github_app_token", async (c) => {
   // Body is optional — callers may include { permissions } to scope the token.
   // CODEOWNERS team groups are verified server-side because github.token does
   // not have the org membership scope required for team membership APIs.
-  let body: {
-    permissions?: import("./oidc").TokenPermissionsInput;
-    codeowners_team_groups?: string[][];
-    actor?: string;
-  } = {};
+  let body: unknown = {};
   try {
     body = await c.req.json();
   } catch {

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -272,7 +272,7 @@ const PERMISSION_RANK: Record<string, number> = { read: 0, write: 1 };
 // - Custom object → merged with defaults; each key clamped to min(default, requested)
 // - Unknown preset name → NO_PUSH (fail-closed; no existing callers to protect)
 // - Non-object / array → NO_PUSH (fail-closed against untrusted JSON)
-export function resolvePermissions(requested?: TokenPermissionsInput): Required<TokenPermissions> {
+export function resolvePermissions(requested?: unknown): Required<TokenPermissions> {
   if (!requested) return { ...DEFAULT_TOKEN_PERMISSIONS };
 
   // Preset name — fail-closed: unrecognized presets get the most restrictive preset
@@ -282,7 +282,7 @@ export function resolvePermissions(requested?: TokenPermissionsInput): Required<
   }
 
   // Reject non-plain-objects (arrays, numbers, etc. from untrusted JSON)
-  if (typeof requested !== "object" || Array.isArray(requested)) {
+  if (!isRecord(requested)) {
     return { ...PERMISSION_PRESETS.NO_PUSH };
   }
 
@@ -403,17 +403,37 @@ function teamRepoHasWriteAccess(teamRepo: TeamRepoResponse | undefined): boolean
   );
 }
 
-export function normalizeCodeownersTeamGroups(body?: ExchangeTokenRequestBody): string[][] | null {
-  if (body && "codeowners_team_groups" in body) {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function normalizeCodeownersTeamGroups(body?: unknown): string[][] | null {
+  if (body === undefined) return [];
+  if (!isRecord(body)) return null;
+
+  if ("codeowners_team_groups" in body) {
     const rawGroups = body.codeowners_team_groups;
     if (!Array.isArray(rawGroups) || rawGroups.length === 0) return null;
     const groups: string[][] = [];
+    const groupKeys = new Set<string>();
     for (const group of rawGroups) {
       if (!Array.isArray(group) || group.length === 0) return null;
-      if (group.some((teamPath) => typeof teamPath !== "string" || !teamPath.trim())) {
-        return null;
+      const normalizedGroup: string[] = [];
+      const teamPaths = new Set<string>();
+      for (const teamPath of group) {
+        if (typeof teamPath !== "string") return null;
+        const normalizedTeamPath = teamPath.trim();
+        if (!normalizedTeamPath) return null;
+        if (!teamPaths.has(normalizedTeamPath)) {
+          teamPaths.add(normalizedTeamPath);
+          normalizedGroup.push(normalizedTeamPath);
+        }
       }
-      groups.push(group);
+      const groupKey = [...normalizedGroup].sort().join("\0");
+      if (!groupKeys.has(groupKey)) {
+        groupKeys.add(groupKey);
+        groups.push(normalizedGroup);
+      }
     }
     return groups;
   }
@@ -626,7 +646,7 @@ export async function handleGetInstallation(
 export async function handleExchangeToken(
   env: Env,
   authHeader: string | null,
-  body?: ExchangeTokenRequestBody,
+  body?: unknown,
 ): Promise<Result<ExchangeTokenResponse, TokenExchangeError>> {
   const oidcToken = extractBearerToken(authHeader);
   if (!oidcToken) {
@@ -675,8 +695,10 @@ export async function handleExchangeToken(
     );
   }
   if (codeownersTeamGroups.length > 0) {
-    const actor = body?.actor ?? claims.actor;
-    if (body?.actor && body.actor.toLowerCase() !== claims.actor.toLowerCase()) {
+    const requestBody = isRecord(body) ? body : {};
+    const requestedActor = typeof requestBody.actor === "string" ? requestBody.actor : undefined;
+    const actor = requestedActor ?? claims.actor;
+    if (requestedActor && requestedActor.toLowerCase() !== claims.actor.toLowerCase()) {
       return Result.err(
         new AuthorizationError({
           message: "CODEOWNERS actor does not match OIDC actor",
@@ -706,7 +728,8 @@ export async function handleExchangeToken(
   }
 
   // Generate scoped token — use caller-provided permissions (clamped to defaults)
-  const permissions = resolvePermissions(body?.permissions);
+  const requestBody = isRecord(body) ? body : {};
+  const permissions = resolvePermissions(requestBody.permissions);
 
   return Result.tryPromise({
     try: async () => {
@@ -719,7 +742,7 @@ export async function handleExchangeToken(
       exchangeLog.info("token_exchanged", {
         installation_id: installationId,
         installation_source: installationSource,
-        requested_permissions: body?.permissions,
+        requested_permissions: requestBody.permissions,
         resolved_permissions: permissions,
       });
 

--- a/src/oidc.ts
+++ b/src/oidc.ts
@@ -5,7 +5,7 @@ import { jwtVerify, createRemoteJWKSet } from "jose";
 import { Result } from "better-result";
 import type { Env } from "./types";
 import { createOctokit, hasWriteAccess, getRepository } from "./github";
-import { createLogger } from "./log";
+import { createLogger, type Logger } from "./log";
 import {
   OIDCValidationError,
   AuthorizationError,
@@ -363,6 +363,244 @@ export interface ExchangeTokenResponse {
   token: string;
 }
 
+export interface ExchangeTokenRequestBody {
+  permissions?: TokenPermissionsInput;
+  codeowners_team_groups?: string[][];
+  actor?: string;
+}
+
+interface TeamResponse {
+  privacy?: string;
+}
+
+interface TeamMembershipResponse {
+  state?: string;
+}
+
+interface TeamRepoResponse {
+  permission?: string;
+  permissions?: {
+    admin?: boolean;
+    push?: boolean;
+    maintain?: boolean;
+  };
+}
+
+interface RepoTeamResponse extends TeamRepoResponse {
+  slug?: string;
+  organization?: {
+    login?: string;
+  };
+}
+
+function teamRepoHasWriteAccess(teamRepo: TeamRepoResponse | undefined): boolean {
+  return Boolean(
+    teamRepo?.permission === "admin" ||
+      teamRepo?.permission === "push" ||
+      teamRepo?.permissions?.admin ||
+      teamRepo?.permissions?.push ||
+      teamRepo?.permissions?.maintain,
+  );
+}
+
+export function normalizeCodeownersTeamGroups(body?: ExchangeTokenRequestBody): string[][] | null {
+  if (body && "codeowners_team_groups" in body) {
+    const rawGroups = body.codeowners_team_groups;
+    if (!Array.isArray(rawGroups) || rawGroups.length === 0) return null;
+    const groups: string[][] = [];
+    for (const group of rawGroups) {
+      if (!Array.isArray(group) || group.length === 0) return null;
+      if (group.some((teamPath) => typeof teamPath !== "string" || !teamPath.trim())) {
+        return null;
+      }
+      groups.push(group);
+    }
+    return groups;
+  }
+  if (body && "codeowners_teams" in body) return null;
+  return [];
+}
+
+function parseTeamPath(teamPath: string): { org: string; slug: string } | null {
+  const [org, slug, extra] = teamPath.split("/");
+  if (!org || !slug || extra) return null;
+  return { org, slug };
+}
+
+export async function checkTeamMembership(
+  token: string,
+  repoOwner: string,
+  repo: string,
+  teamPath: string,
+  actor: string,
+  logger: Logger,
+): Promise<boolean> {
+  const parsed = parseTeamPath(teamPath);
+  if (!parsed) {
+    logger.warn("codeowners_team_invalid", { team_path: teamPath });
+    return false;
+  }
+
+  if (parsed.org.toLowerCase() !== repoOwner.toLowerCase()) {
+    logger.warn("codeowners_team_cross_org", { team_path: teamPath, team_org: parsed.org });
+    return false;
+  }
+
+  const baseUrl = `https://api.github.com/orgs/${encodeURIComponent(parsed.org)}/teams/${encodeURIComponent(parsed.slug)}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  try {
+    const teamResp = await fetch(baseUrl, { headers });
+    if (teamResp.status !== 200) {
+      if (teamResp.status !== 404) {
+        logger.warn("codeowners_team_api_error", {
+          team_path: teamPath,
+          status: teamResp.status,
+          body: (await teamResp.text()).slice(0, 200),
+        });
+      }
+      return false;
+    }
+
+    const team = (await teamResp.json()) as TeamResponse;
+    if (team.privacy === "secret") {
+      logger.warn("codeowners_team_secret", { team_path: teamPath });
+      return false;
+    }
+
+    const membershipResp = await fetch(
+      `${baseUrl}/memberships/${encodeURIComponent(actor)}`,
+      { headers },
+    );
+    if (membershipResp.status !== 200) {
+      if (membershipResp.status !== 404) {
+        logger.warn("codeowners_team_membership_api_error", {
+          team_path: teamPath,
+          status: membershipResp.status,
+          body: (await membershipResp.text()).slice(0, 200),
+        });
+      }
+      return false;
+    }
+
+    const membership = (await membershipResp.json()) as TeamMembershipResponse;
+    if (membership.state !== "active") return false;
+
+    const repoResp = await fetch(
+      `${baseUrl}/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repo)}`,
+      {
+        headers: {
+          ...headers,
+          Accept: "application/vnd.github.v3.repository+json",
+        },
+      },
+    );
+    if (repoResp.status === 204) {
+      return findTeamRepoAccess(token, repoOwner, repo, parsed.org, parsed.slug, logger);
+    }
+    if (repoResp.status !== 200) {
+      if (repoResp.status !== 404) {
+        logger.warn("codeowners_team_repo_api_error", {
+          team_path: teamPath,
+          status: repoResp.status,
+          body: (await repoResp.text()).slice(0, 200),
+        });
+      }
+      return false;
+    }
+
+    const teamRepo = (await repoResp.json()) as TeamRepoResponse;
+    return teamRepoHasWriteAccess(teamRepo);
+  } catch (err) {
+    logger.errorWithException("codeowners_team_check_failed", err, { team_path: teamPath });
+    return false;
+  }
+}
+
+async function findTeamRepoAccess(
+  token: string,
+  repoOwner: string,
+  repo: string,
+  teamOrg: string,
+  teamSlug: string,
+  logger: Logger,
+): Promise<boolean> {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  try {
+    for (let page = 1; ; page += 1) {
+      const resp = await fetch(
+        `https://api.github.com/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repo)}/teams?per_page=100&page=${page}`,
+        { headers },
+      );
+      if (resp.status !== 200) {
+        if (resp.status !== 404) {
+          logger.warn("codeowners_repo_teams_api_error", {
+            team_path: `${teamOrg}/${teamSlug}`,
+            status: resp.status,
+            body: (await resp.text()).slice(0, 200),
+          });
+        }
+        return false;
+      }
+
+      const teams = (await resp.json()) as RepoTeamResponse[];
+      const match = teams.find(
+        (team) =>
+          team.slug === teamSlug && team.organization?.login?.toLowerCase() === teamOrg.toLowerCase(),
+      );
+      if (match) return teamRepoHasWriteAccess(match);
+      if (teams.length < 100) return false;
+    }
+  } catch (err) {
+    logger.errorWithException("codeowners_repo_teams_fetch_failed", err, {
+      team_path: `${teamOrg}/${teamSlug}`,
+    });
+    return false;
+  }
+}
+
+async function verifyCodeownersTeamGroups(
+  env: Env,
+  installationId: number,
+  owner: string,
+  repo: string,
+  actor: string,
+  groups: string[][],
+  logger: Logger,
+): Promise<boolean> {
+  let unscopedToken: string;
+  try {
+    unscopedToken = await generateInstallationToken(env, installationId);
+  } catch (err) {
+    logger.errorWithException("codeowners_team_token_failed", err);
+    return false;
+  }
+
+  for (const group of groups) {
+    let groupPassed = false;
+    for (const teamPath of group) {
+      if (typeof teamPath !== "string") continue;
+      if (await checkTeamMembership(unscopedToken, owner, repo, teamPath, actor, logger)) {
+        logger.info("codeowners_team_verified", { actor, team_path: teamPath });
+        groupPassed = true;
+        break;
+      }
+    }
+    if (!groupPassed) return false;
+  }
+
+  return true;
+}
+
 // Handler for GET /get_github_app_installation
 export async function handleGetInstallation(
   env: Env,
@@ -388,7 +626,7 @@ export async function handleGetInstallation(
 export async function handleExchangeToken(
   env: Env,
   authHeader: string | null,
-  body?: { permissions?: TokenPermissionsInput },
+  body?: ExchangeTokenRequestBody,
 ): Promise<Result<ExchangeTokenResponse, TokenExchangeError>> {
   const oidcToken = extractBearerToken(authHeader);
   if (!oidcToken) {
@@ -426,6 +664,46 @@ export async function handleExchangeToken(
     return Result.err(installationResult.error);
   }
   const { id: installationId, source: installationSource } = installationResult.value;
+
+  const codeownersTeamGroups = normalizeCodeownersTeamGroups(body);
+  if (codeownersTeamGroups === null) {
+    return Result.err(
+      new AuthorizationError({
+        message: "codeowners_teams is unsupported; use codeowners_team_groups",
+        reason: "invalid_format",
+      }),
+    );
+  }
+  if (codeownersTeamGroups.length > 0) {
+    const actor = body?.actor ?? claims.actor;
+    if (body?.actor && body.actor.toLowerCase() !== claims.actor.toLowerCase()) {
+      return Result.err(
+        new AuthorizationError({
+          message: "CODEOWNERS actor does not match OIDC actor",
+          reason: "invalid_format",
+        }),
+      );
+    }
+
+    const verified = await verifyCodeownersTeamGroups(
+      env,
+      installationId,
+      owner,
+      repo,
+      actor,
+      codeownersTeamGroups,
+      exchangeLog,
+    );
+    if (!verified) {
+      exchangeLog.warn("codeowners_team_denied", { actor, groups: codeownersTeamGroups });
+      return Result.err(
+        new AuthorizationError({
+          message: `${actor} is not a member of every required CODEOWNERS team group`,
+          reason: "no_write_access",
+        }),
+      );
+    }
+  }
 
   // Generate scoped token — use caller-provided permissions (clamped to defaults)
   const permissions = resolvePermissions(body?.permissions);

--- a/test/github-script.spec.ts
+++ b/test/github-script.spec.ts
@@ -390,6 +390,40 @@ src @src-owner
     fetchMock.mockRestore();
     exit.mockRestore();
   });
+
+  it("dedupes repeated CODEOWNERS team groups before server verification", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ changed_files: 2, base: { sha: "base-sha" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: Buffer.from("src/** @org/security").toString("base64") }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ filename: "src/a.ts" }, { filename: "src/b.ts" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ permission: "write" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    await expect(
+      withEnv({ PR_NUMBER: "1", ISSUE_NUMBER: undefined }, () =>
+        checkCodeowners("owner", "repo", "main", "alice", "token"),
+      ),
+    ).resolves.toEqual({ teamGroups: [["org/security"]] });
+  });
 });
 
 describe("GitHub Action OIDC base URL", () => {

--- a/test/github-script.spec.ts
+++ b/test/github-script.spec.ts
@@ -4,9 +4,40 @@ import {
   parseTokenPermissions,
   checkPermissionLevel,
   extractMentionPrompt,
+  getApiBaseUrl,
 } from "../github/script/context";
 import { fetchWithRetry } from "../github/script/http";
+import {
+  buildPrompt,
+  checkCodeowners,
+  findMatchingCodeownersRule,
+  parseCodeowners,
+} from "../github/script/orchestrate";
 import { isRetryableOpenCodeFailure } from "../github/script/run-opencode";
+
+async function withEnv<T>(values: Record<string, string | undefined>, fn: () => Promise<T> | T): Promise<T> {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(values)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
 
 describe("GitHub Action script context", () => {
   beforeEach(() => {
@@ -86,6 +117,308 @@ describe("GitHub Action mention prompt extraction", () => {
 
   it("ignores comments without a configured mention", () => {
     expect(extractMentionPrompt("please fix this", "/bonk,@ask-bonk")).toBeNull();
+  });
+});
+
+describe("GitHub Action preflight prompt", () => {
+  it("preserves plain issue comment prompts", async () => {
+    const result = await withEnv(
+      {
+        EVENT_NAME: "issue_comment",
+        USER_PROMPT: undefined,
+        COMMENT_BODY: "/bonk summarize this issue",
+        REVIEW_BODY: undefined,
+        MENTIONS: "/bonk,@ask-bonk",
+        PR_NUMBER: undefined,
+        ISSUE_NUMBER: "42",
+        REPOSITORY: "owner/repo",
+        PR_HEAD_REPO: undefined,
+        PR_BASE_REPO: undefined,
+        PR_URL: undefined,
+        GH_TOKEN: undefined,
+      },
+      () => buildPrompt(),
+    );
+
+    expect(result).toEqual({
+      isFork: false,
+      detectionFailed: false,
+      value: "/bonk summarize this issue",
+    });
+  });
+});
+
+describe("GitHub Action CODEOWNERS matching", () => {
+  it("uses the last matching rule for changed files", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+/src/** @org/source-team
+/src/generated/** @generated-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "README.md")?.owners).toEqual(["global-owner"]);
+    expect(findMatchingCodeownersRule(rules, "src/index.ts")?.teams).toEqual(["org/source-team"]);
+    expect(findMatchingCodeownersRule(rules, "src/generated/client.ts")?.owners).toEqual([
+      "generated-owner",
+    ]);
+  });
+
+  it("preserves ownerless override rules", () => {
+    const rules = parseCodeowners(`
+/apps/ @alice
+/apps/github
+`);
+
+    expect(findMatchingCodeownersRule(rules, "apps/github/action.ts")).toEqual({
+      pattern: "/apps/github",
+      owners: [],
+      teams: [],
+      unsupportedOwners: [],
+      unsupportedPattern: false,
+    });
+  });
+
+  it("matches unanchored directory patterns below any parent", () => {
+    const rules = parseCodeowners("apps/ @alice");
+
+    expect(findMatchingCodeownersRule(rules, "apps/index.ts")?.owners).toEqual(["alice"]);
+    expect(findMatchingCodeownersRule(rules, "packages/apps/index.ts")?.owners).toEqual([
+      "alice",
+    ]);
+  });
+
+  it("keeps middle-slash directory patterns root-relative", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+build/logs/ @logs-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "build/logs/a.txt")?.owners).toEqual([
+      "logs-owner",
+    ]);
+    expect(findMatchingCodeownersRule(rules, "src/build/logs/a.txt")?.owners).toEqual([
+      "global-owner",
+    ]);
+  });
+
+  it("matches glob directory patterns below descendants", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+**/logs @logs-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "logs/app.log")?.owners).toEqual(["logs-owner"]);
+    expect(findMatchingCodeownersRule(rules, "build/logs/app.log")?.owners).toEqual([
+      "logs-owner",
+    ]);
+  });
+
+  it("keeps middle-slash patterns root-relative unless they use globstar", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+docs/* @docs-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "docs/readme.md")?.owners).toEqual([
+      "docs-owner",
+    ]);
+    expect(findMatchingCodeownersRule(rules, "packages/docs/readme.md")?.owners).toEqual([
+      "global-owner",
+    ]);
+    expect(findMatchingCodeownersRule(rules, "docs/build-app/troubleshooting.md")?.owners).toEqual([
+      "global-owner",
+    ]);
+  });
+
+  it("matches globstar slash as zero or more directories", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+src/**/secrets.yml @security-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "src/secrets.yml")?.owners).toEqual([
+      "security-owner",
+    ]);
+    expect(findMatchingCodeownersRule(rules, "src/config/secrets.yml")?.owners).toEqual([
+      "security-owner",
+    ]);
+  });
+
+  it("keeps non-special double stars within a path segment", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+foo**bar @literal-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "fooXXbar")?.owners).toEqual(["literal-owner"]);
+    expect(findMatchingCodeownersRule(rules, "foo/x/bar")?.owners).toEqual(["global-owner"]);
+  });
+
+  it("parses escaped spaces in patterns", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+/docs/My\\ File.md @docs-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "docs/My File.md")?.owners).toEqual([
+      "docs-owner",
+    ]);
+  });
+
+  it("parses escaped glob metacharacters as literals", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+/secrets/\\*.yml @literal-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "secrets/*.yml")?.owners).toEqual([
+      "literal-owner",
+    ]);
+    expect(findMatchingCodeownersRule(rules, "secrets/prod.yml")?.owners).toEqual([
+      "global-owner",
+    ]);
+  });
+
+  it("marks escaped leading hash rules unsupported", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+\\#secrets.yml @hash-owner
+`);
+
+    expect(rules[1]?.unsupportedPattern).toBe(true);
+  });
+
+  it("preserves unsupported owner tokens for fail-closed authorization", () => {
+    const rules = parseCodeowners("src/** security@example.com");
+
+    expect(findMatchingCodeownersRule(rules, "src/app.ts")?.unsupportedOwners).toEqual([
+      "security@example.com",
+    ]);
+  });
+
+  it("matches slashless literal directory patterns below descendants", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+src @src-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "src/app.ts")?.owners).toEqual(["src-owner"]);
+  });
+
+  it("marks unescaped bracket patterns unsupported", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+/src/[ab].ts @src-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "src/[ab].ts")?.unsupportedPattern).toBe(true);
+  });
+
+  it("keeps hash characters inside pattern fields", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+/docs/#private @private-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "docs/#private")?.owners).toEqual([
+      "private-owner",
+    ]);
+  });
+
+  it("marks leading bang patterns unsupported", () => {
+    const rules = parseCodeowners("!/secrets @security-owner");
+
+    expect(rules[0]?.unsupportedPattern).toBe(true);
+  });
+
+  it("matches wildcard directory-like patterns below descendants", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+**/secret* @security-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "src/secret-prod/key.yml")?.owners).toEqual([
+      "security-owner",
+    ]);
+  });
+
+  it("matches dotted wildcard directory-like patterns below descendants", () => {
+    const rules = parseCodeowners(`
+* @global-owner
+**/config.* @security-owner
+`);
+
+    expect(findMatchingCodeownersRule(rules, "src/config.prod/key.yml")?.owners).toEqual([
+      "security-owner",
+    ]);
+  });
+
+  it("does not fall through empty higher-priority CODEOWNERS files", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ changed_files: 1, base: { sha: "base-sha" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: "" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ filename: "README.md" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await expect(
+      withEnv({ PR_NUMBER: "1", ISSUE_NUMBER: undefined }, () =>
+        checkCodeowners("owner", "repo", "main", "alice", "token"),
+      ),
+    ).rejects.toThrow(
+      "exit:1",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(exit).toHaveBeenCalledWith(1);
+    fetchMock.mockRestore();
+    exit.mockRestore();
+  });
+});
+
+describe("GitHub Action OIDC base URL", () => {
+  it("normalizes the auth endpoint to the API base", () => {
+    return withEnv({ OIDC_BASE_URL: "https://ask-bonk.example/auth/" }, () => {
+      expect(getApiBaseUrl()).toBe("https://ask-bonk.example");
+    });
+  });
+
+  it("rejects credentials, query strings, and fragments", async () => {
+    await expect(
+      withEnv({ OIDC_BASE_URL: "https://user:pass@ask-bonk.example/auth" }, () => getApiBaseUrl()),
+    ).rejects.toThrow("must not include credentials");
+
+    await expect(
+      withEnv({ OIDC_BASE_URL: "https://ask-bonk.example/auth?token=1" }, () => getApiBaseUrl()),
+    ).rejects.toThrow("must not include credentials");
+
+    await expect(
+      withEnv({ OIDC_BASE_URL: "https://ask-bonk.example/auth#frag" }, () => getApiBaseUrl()),
+    ).rejects.toThrow("must not include credentials");
+
+    await expect(
+      withEnv({ OIDC_BASE_URL: "https://ask-bonk.example/auth?" }, () => getApiBaseUrl()),
+    ).rejects.toThrow("must not include credentials");
+
+    await expect(
+      withEnv({ OIDC_BASE_URL: "https://ask-bonk.example/auth#" }, () => getApiBaseUrl()),
+    ).rejects.toThrow("must not include credentials");
   });
 });
 

--- a/test/github-script.spec.ts
+++ b/test/github-script.spec.ts
@@ -149,6 +149,10 @@ describe("GitHub Action preflight prompt", () => {
 });
 
 describe("GitHub Action CODEOWNERS matching", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("uses the last matching rule for changed files", () => {
     const rules = parseCodeowners(`
 * @global-owner
@@ -351,6 +355,136 @@ src @src-owner
     expect(findMatchingCodeownersRule(rules, "src/config.prod/key.yml")?.owners).toEqual([
       "security-owner",
     ]);
+  });
+
+  it("fails closed on unsupported CODEOWNERS pattern syntax during authorization", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ changed_files: 1, base: { sha: "base-sha" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: Buffer.from("!/secrets @security-owner").toString("base64") }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await expect(
+      withEnv({ PR_NUMBER: "1", ISSUE_NUMBER: undefined }, () =>
+        checkCodeowners("owner", "repo", "main", "alice", "token"),
+      ),
+    ).rejects.toThrow("exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("fails closed on unsupported CODEOWNERS owners during authorization", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ changed_files: 1, base: { sha: "base-sha" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: Buffer.from("src/** security@example.com").toString("base64") }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ filename: "src/app.ts" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await expect(
+      withEnv({ PR_NUMBER: "1", ISSUE_NUMBER: undefined }, () =>
+        checkCodeowners("owner", "repo", "main", "alice", "token"),
+      ),
+    ).rejects.toThrow("exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("requires write permission for ownerless CODEOWNERS overrides", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ changed_files: 1, base: { sha: "base-sha" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: Buffer.from("/apps/ @alice\n/apps/github").toString("base64") }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ filename: "apps/github/action.ts" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ permission: "read" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+
+    await expect(
+      withEnv({ PR_NUMBER: "1", ISSUE_NUMBER: undefined }, () =>
+        checkCodeowners("owner", "repo", "main", "alice", "token"),
+      ),
+    ).rejects.toThrow("exit:1");
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("allows ownerless CODEOWNERS overrides when the actor has write permission", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ changed_files: 1, base: { sha: "base-sha" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: Buffer.from("/apps/ @alice\n/apps/github").toString("base64") }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([{ filename: "apps/github/action.ts" }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ permission: "write" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    await expect(
+      withEnv({ PR_NUMBER: "1", ISSUE_NUMBER: undefined }, () =>
+        checkCodeowners("owner", "repo", "main", "alice", "token"),
+      ),
+    ).resolves.toEqual({ teamGroups: [] });
   });
 
   it("does not fall through empty higher-priority CODEOWNERS files", async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { Hono } from "hono";
 import {
   extractPrompt,
@@ -13,6 +13,8 @@ import {
   extractBearerToken,
   handleExchangeTokenForRepo,
   handleExchangeTokenWithPAT,
+  checkTeamMembership,
+  normalizeCodeownersTeamGroups,
   resolvePermissions,
 } from "../src/oidc";
 import { sanitizeSecrets } from "../src/log";
@@ -26,6 +28,19 @@ import {
 import { validateOpenCodeVersion } from "../github/script/context";
 import type { Env } from "../src/types";
 import type { WorkflowRunPayload } from "../src/types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const testLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  errorWithException: vi.fn(),
+  child: vi.fn(),
+};
 
 // Proxy-based mock Env that throws on unexpected property access.
 // Ensures tests only touch properties they explicitly provide, preventing
@@ -424,6 +439,129 @@ describe("Authorization Header Parsing", () => {
     expect(extractBearerToken("Basic token123")).toBeNull();
     expect(extractBearerToken(null)).toBeNull();
     expect(extractBearerToken(undefined)).toBeNull();
+  });
+});
+
+describe("CODEOWNERS team verification", () => {
+  it("rejects legacy flat team lists", () => {
+    expect(normalizeCodeownersTeamGroups({ codeowners_teams: ["org/team"] } as any)).toBeNull();
+  });
+
+  it("rejects malformed team group shapes", () => {
+    expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: [] })).toBeNull();
+    expect(
+      normalizeCodeownersTeamGroups({ codeowners_team_groups: null } as any),
+    ).toBeNull();
+    expect(
+      normalizeCodeownersTeamGroups({ codeowners_team_groups: "org/team" } as any),
+    ).toBeNull();
+    expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: 1 } as any)).toBeNull();
+    expect(
+      normalizeCodeownersTeamGroups({ codeowners_team_groups: { team: "org/team" } as any }),
+    ).toBeNull();
+    expect(
+      normalizeCodeownersTeamGroups({ codeowners_team_groups: ["org/team"] as any }),
+    ).toBeNull();
+    expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: [[]] })).toBeNull();
+    expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: [[""]] })).toBeNull();
+  });
+
+  it("rejects secret teams", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ privacy: "secret" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(
+      checkTeamMembership("token", "org", "repo", "org/security", "alice", testLogger as any),
+    ).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts visible active teams with write repo permissions", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ privacy: "closed" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ state: "active" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ permission: "push" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+
+    await expect(
+      checkTeamMembership("token", "org", "repo", "org/security", "alice", testLogger as any),
+    ).resolves.toBe(true);
+  });
+
+  it("handles 204 team-repo checks through explicit repo team permissions", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ privacy: "closed" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ state: "active" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            { slug: "security", organization: { login: "org" }, permission: "push" },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    await expect(
+      checkTeamMembership("token", "org", "repo", "org/security", "alice", testLogger as any),
+    ).resolves.toBe(true);
+  });
+
+  it("fails closed when 204 fallback only finds read team permissions", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ privacy: "closed" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ state: "active" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            { slug: "security", organization: { login: "org" }, permission: "pull" },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    await expect(
+      checkTeamMembership("token", "org", "repo", "org/security", "alice", testLogger as any),
+    ).resolves.toBe(false);
   });
 });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -448,6 +448,10 @@ describe("CODEOWNERS team verification", () => {
   });
 
   it("rejects malformed team group shapes", () => {
+    expect(normalizeCodeownersTeamGroups(null as any)).toBeNull();
+    expect(normalizeCodeownersTeamGroups("x" as any)).toBeNull();
+    expect(normalizeCodeownersTeamGroups(1 as any)).toBeNull();
+    expect(normalizeCodeownersTeamGroups([] as any)).toBeNull();
     expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: [] })).toBeNull();
     expect(
       normalizeCodeownersTeamGroups({ codeowners_team_groups: null } as any),
@@ -464,6 +468,20 @@ describe("CODEOWNERS team verification", () => {
     ).toBeNull();
     expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: [[]] })).toBeNull();
     expect(normalizeCodeownersTeamGroups({ codeowners_team_groups: [[""]] })).toBeNull();
+  });
+
+  it("dedupes normalized team groups", () => {
+    expect(
+      normalizeCodeownersTeamGroups({
+        codeowners_team_groups: [
+          ["org/security"],
+          [" org/security "],
+          ["org/platform", "org/platform"],
+          ["org/release", "org/docs"],
+          ["org/docs", "org/release"],
+        ],
+      }),
+    ).toEqual([["org/security"], ["org/platform"], ["org/release", "org/docs"]]);
   });
 
   it("rejects secret teams", async () => {

--- a/tsconfig.github-action.json
+++ b/tsconfig.github-action.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2024", "dom", "dom.iterable"],
+    "types": ["node"]
+  },
+  "include": ["github/script/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Harden the composite action and token exchange path so push-capable credentials and CODEOWNERS-derived trust fail closed.

- Confines App installation tokens to step outputs, clears checkout credentials for forks, and keeps finalization from inheriting push-capable remotes.
- Adds OIDC URL validation, token caching, action script typechecking, and timeout/process cleanup hardening.
- Preserves Bonk issue-comment prompts during preflight and maps read-only CLI workflows to NO_PUSH.
- Moves CODEOWNERS team verification server-side, based on #174, so checks use App credentials instead of github.token.
- Rejects malformed, incomplete, or unsupported CODEOWNERS inputs rather than silently bypassing required reviews.
- Covers the action parser and Worker exchange path with focused fail-closed tests.

CODEOWNERS before vs. after:
- Before: client-side team membership checks depended on github.token permissions; after: the Worker verifies teams with App installation credentials.
- Before: flat codeowners_teams could collapse owner groups into an unsafe OR; after: per-file, per-rule team groups preserve AND semantics.
- Before: unsupported CODEOWNERS syntax, empty higher-priority files, renames, secret teams, and API caps could pass ambiguously; after: those cases block push-token exchange.

Verification:
- bun run tsc --noEmit
- bun run typecheck:action
- bun run test
- bun run lint
- git diff --check