### PR TITLE
avoid global runtime APIs during deploy

### DIFF
--- a/src/channels/github.ts
+++ b/src/channels/github.ts
@@ -1,12 +1,8 @@
-import { createGitHubChannel } from "@flue/github";
+import { createGitHubChannel, type GitHubChannel } from "@flue/github";
 import { handleGitHubDelivery } from "../app";
 import type { Env } from "../types";
 
 type GitHubChannelEnv = { Bindings: Env };
-
-// If the runtime secret binding is missing, use an unguessable value so the
-// generated Flue webhook route fails closed instead of accepting a public secret.
-const missingWebhookSecret = crypto.randomUUID();
 
 export function createGitHubWebhookChannel(webhookSecret: string) {
   return createGitHubChannel<GitHubChannelEnv>({
@@ -15,6 +11,29 @@ export function createGitHubWebhookChannel(webhookSecret: string) {
   });
 }
 
-export const channel = createGitHubWebhookChannel(
-  process.env.GITHUB_WEBHOOK_SECRET || missingWebhookSecret,
-);
+// Reuse upstream conversationKey/parseConversationKey behavior while replacing
+// the route below so this sentinel secret is never used for webhook verification.
+const conversationKeyChannel = createGitHubWebhookChannel("route-overridden");
+
+// Resolve the secret from Worker bindings inside the handler. Secrets may not be
+// available through process.env during module initialization, and global-scope
+// fallbacks must not accept a public webhook secret.
+export const channel: GitHubChannel<GitHubChannelEnv> = {
+  ...conversationKeyChannel,
+  routes: [
+    {
+      method: "POST",
+      path: "/webhook",
+      handler: async (c) => {
+        const webhookSecret = c.env.GITHUB_WEBHOOK_SECRET;
+        if (!webhookSecret) return new Response(null, { status: 401 });
+
+        const webhookRoute = createGitHubWebhookChannel(webhookSecret).routes[0];
+        if (!webhookRoute) {
+          return new Response("GitHub webhook route is unavailable", { status: 500 });
+        }
+        return webhookRoute.handler(c, async () => undefined);
+      },
+    },
+  ],
+};

--- a/src/internal-workflows.ts
+++ b/src/internal-workflows.ts
@@ -4,10 +4,15 @@ export const INTERNAL_WORKFLOW_HEADER = "x-bonk-internal-workflow";
 
 // Internal compatibility routes call Flue workflows in-process. External callers
 // must continue to use the OIDC-protected /api/github/* routes.
-const internalWorkflowToken = crypto.randomUUID();
+let internalWorkflowToken: string | undefined;
+
+function getInternalWorkflowToken(): string {
+  internalWorkflowToken ??= crypto.randomUUID();
+  return internalWorkflowToken;
+}
 
 export const internalWorkflowRoute: WorkflowRouteHandler = async (c, next) => {
-  if (c.req.header(INTERNAL_WORKFLOW_HEADER) !== internalWorkflowToken) {
+  if (c.req.header(INTERNAL_WORKFLOW_HEADER) !== getInternalWorkflowToken()) {
     return c.notFound();
   }
   await next();
@@ -16,6 +21,6 @@ export const internalWorkflowRoute: WorkflowRouteHandler = async (c, next) => {
 export function internalWorkflowHeaders(): Headers {
   return new Headers({
     "Content-Type": "application/json",
-    [INTERNAL_WORKFLOW_HEADER]: internalWorkflowToken,
+    [INTERNAL_WORKFLOW_HEADER]: getInternalWorkflowToken(),
   });
 }


### PR DESCRIPTION
Cloudflare deploy validation rejects Workers that call runtime-only APIs during module initialization.

The Pages deploy failed after Flue built successfully because the generated Worker called `crypto.randomUUID()` at global scope for the GitHub webhook fallback. The internal workflow token had the same eager global-scope pattern and would become the next validation failure.

- resolve the canonical Flue GitHub webhook secret from Worker bindings inside the request handler
- keep the webhook route fail-closed when `GITHUB_WEBHOOK_SECRET` is missing
- lazily generate the internal workflow token only when internal workflow requests run
- confirmed the rebuilt bundle has no top-level `crypto.randomUUID()` assignments

Tests:
- `bun run tsc --noEmit`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bunx wrangler types --check`
- `bunx wrangler deploy --dry-run --config dist/ask_bonk/wrangler.json --var BONK_VERSION:ci --var BONK_COMMIT:local`