### PR TITLE
Use GLM-5.2 for Bonk workflows

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -35,8 +35,9 @@ jobs:
           # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
           # approval prompts. This is intentionally not in opencode.jsonc so
           # local/interactive sessions keep their normal permission prompts.
-          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
+          OPENCODE_CONFIG_CONTENT: >-
+            {"permission":"allow","provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/zai-org/glm-5.2":{"reasoning":true,"tool_call":true,"temperature":true,"limit":{"context":262144,"output":262144}}}}}}
         with:
-          model: "cloudflare-ai-gateway/openai/gpt-5.6-sol"
+          model: cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2
           mentions: "/bonk"
           permissions: write

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -71,9 +71,10 @@ jobs:
           # Auto-approve tool calls in CI only, so Bonk doesn't get stuck on
           # approval prompts. This is intentionally not in opencode.jsonc so
           # local/interactive sessions keep their normal permission prompts.
-          OPENCODE_CONFIG_CONTENT: '{"permission":"allow"}'
+          OPENCODE_CONFIG_CONTENT: >-
+            {"permission":"allow","provider":{"cloudflare-ai-gateway":{"models":{"workers-ai/@cf/zai-org/glm-5.2":{"reasoning":true,"tool_call":true,"temperature":true,"limit":{"context":262144,"output":262144}}}}}}
         with:
-          model: cloudflare-ai-gateway/openai/gpt-5.6-sol
+          model: cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2
           mentions: "/review"
           permissions: write
           agent: reviewer


### PR DESCRIPTION
Switch Bonk and automated reviews to Workers AI GLM-5.2 through Cloudflare AI Gateway.

OpenCode’s bundled AI Gateway catalog does not yet include GLM-5.2, so selecting the model alone would fail before reaching the gateway.

- Route both workflows to `workers-ai/@cf/zai-org/glm-5.2`
- Register GLM-5.2 capabilities and token limits in the injected OpenCode config
- Keep CI tool permissions unchanged

Validated with TypeScript, 172 tests, lint, and OpenCode model resolution.